### PR TITLE
Fix to work enter animation with CSSTransitionGroup

### DIFF
--- a/src/CSSTransitionGroupChild.js
+++ b/src/CSSTransitionGroupChild.js
@@ -125,6 +125,11 @@ class CSSTransitionGroupChild extends React.Component {
   flushClassNameAndNodeQueue() {
     if (!this.unmounted) {
       this.classNameAndNodeQueue.forEach((obj) => {
+        // This is for to force a repaint,
+        // which is necessary in order to transition styles when adding a class name.
+        /* eslint-disable no-unused-expressions */
+        obj.node.scrollTop;
+        /* eslint-enable no-unused-expressions */
         addClass(obj.node, obj.className);
       });
     }
@@ -165,6 +170,7 @@ class CSSTransitionGroupChild extends React.Component {
     delete props.appearTimeout;
     delete props.enterTimeout;
     delete props.leaveTimeout;
+    delete props.children;
     return React.cloneElement(React.Children.only(this.props.children), props);
   }
 }


### PR DESCRIPTION
This PR is to fix #5.

Currently, enter animation with CSSTransitionGroup seems not to work as mentioned in #5.

The following is a reproduce case.

* Using `react-addons-css-transition-group` (works fine)
    * http://www.webpackbin.com/NyJBZC7uf
    * ![screen shot 2017-02-08 at 17 04 39](https://cloud.githubusercontent.com/assets/250407/22733494/54439b20-ee35-11e6-85e2-20b8304710ac.png)

* Using `react-transition-group` (enter animation doesn't work)
    * http://www.webpackbin.com/Ey8UzR7_M
    * ![screen shot 2017-02-08 at 17 08 20](https://cloud.githubusercontent.com/assets/250407/22733505/611c55bc-ee35-11e6-877b-a3f049449cdd.png)
   
According to the above Chrome timeline images, `react-transition-group` calls `flushClassNameAndNodeQueue` before recalculate and repaint.
I think this is the cause of the issue.

So the PR is using `setTimeout` with `TICK = 17`, which is same as the original implementation in `react-addons-css-transition-group`.

After applying the above patch, `CSSTransitionGroupChild` creates nested duplicate children.
It can fix not to pass children to `React.cloneElement`

![screen shot 2017-02-08 at 19 41 24](https://cloud.githubusercontent.com/assets/250407/22733782/9c673a32-ee36-11e6-8f60-59c8a069d344.png)
