### PR TITLE
Check that the component exists on leave

### DIFF
--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -149,7 +149,7 @@ class TransitionGroup extends React.Component {
     this.currentlyTransitioningKeys[key] = true;
 
     let component = this.childRefs[key];
-    if (component.componentWillLeave) {
+    if (component && component.componentWillLeave) {
       component.componentWillLeave(this._handleDoneLeaving.bind(this, key));
     } else {
       // Note that this is somewhat dangerous b/c it calls setState()


### PR DESCRIPTION
When using transition group inside a component that is unmounted using `React.unmountComponentAtNode`, the `component` object seems to get destroyed. This cuases an uncaught error: 
```
null is not an object (evaluating 'component.componentWillLeave')
```
For me, this really is only an issue in tests, where I'm ensuring `componentDidLeave` calls a callback method.

I figured it is such a small change, it would be worth fixing, even though it's a bit of an edge case.

Thanks for your time maintaining this module. We make extensive use of it in our applications. 