### PR TITLE
Proposed fix for #29

### DIFF
--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -204,11 +204,9 @@ class TransitionGroup extends React.Component {
           this.props.childFactory(child),
           {
             key,
-            ref: chain(
-              isCallbackRef ? child.ref : null,
-              (r) => {
-                this.childRefs[key] = r;
-              }),
+            ref: (r) => {
+              this.childRefs[key] = r;
+            },
           },
         ));
       }

--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -191,9 +191,22 @@ class TransitionGroup extends React.Component {
       let child = this.state.children[key];
       if (child) {
         let isCallbackRef = typeof child.ref !== 'string';
+        let factoryChild = this.props.childFactory(child);
+        let ref = (r) => {
+          this.childRefs[key] = r;
+        };
+
         warning(isCallbackRef,
           'string refs are not supported on children of TransitionGroup and will be ignored. ' +
           'Please use a callback ref instead: https://facebook.github.io/react/docs/refs-and-the-dom.html#the-ref-callback-attribute');
+
+        // Always chaining the refs leads to problems when the childFactory
+        // wraps the child. The child ref callback gets called twice with the
+        // wrapper and the child. So we only need to chain the ref if the
+        // factoryChild is not different from child.
+        if (factoryChild === child && isCallbackRef) {
+          ref = chain(child.ref, ref);
+        }
 
         // You may need to apply reactive updates to a child as it is leaving.
         // The normal React way to do it won't work since the child will have
@@ -201,12 +214,10 @@ class TransitionGroup extends React.Component {
         // a childFactory function to wrap every child, even the ones that are
         // leaving.
         childrenToRender.push(React.cloneElement(
-          this.props.childFactory(child),
+          factoryChild,
           {
             key,
-            ref: (r) => {
-              this.childRefs[key] = r;
-            },
+            ref,
           },
         ));
       }


### PR DESCRIPTION
This was hijacking the child ref onto the `CSSTransitionGroupChild`, this fix for #29 leaves the ref on child and lets the `TransitionGroup` add a ref to the wrapped child produced from `childFactory()`.  (assumption: `childFactory()` always wraps the child) An improvement would to detect if the child was wrapped or not and chain appropriately.