### PR TITLE
Fixed link for TransitionGroup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A ton of thanks to the React team, and contributors for writing and maintaining 
 
 ---
 
-The [`TransitionGroup`](#transitiongroup) add-on component is a low-level API for animation, and [`CSSTransitionGroup`](#csstransitiongroup) is an add-on component for easily implementing basic CSS animations and transitions.
+The [`TransitionGroup`](#low-level-api-transitiongroup) add-on component is a low-level API for animation, and [`CSSTransitionGroup`](#csstransitiongroup) is an add-on component for easily implementing basic CSS animations and transitions.
 
 ## High-level API: CSSTransitionGroup
 


### PR DESCRIPTION
As I was reading the README I found out there are 2 `TransitionGroup` links in the README file. The other one redirects correctly and this one doesn't so I fixed it.