### PR TITLE
Add loose-envify browserify transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "chain-function": "^1.0.0",
     "dom-helpers": "^3.2.0",
+    "loose-envify": "^1.3.1",
     "prop-types": "^15.5.6",
     "warning": "^3.0.0"
   },
@@ -74,5 +75,10 @@
   },
   "release-script": {
     "altPkgRootFolder": "lib"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2842,9 +2842,9 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  resolved "https://artifacts.netflix.com/api/npm/npm-netflix/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
 


### PR DESCRIPTION
Related to https://github.com/facebook/react/issues/9641

This tells browserify to remove `process.env.NODE_ENV` conditionals during bundling.