### PR TITLE
Incorporated development + production builds into /dist (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v1.1.X]
+> 2017-XX-XX
+
+- **Feature:** Dist build now includes both production and development builds ([#64])
+
 ## [v1.1.3]
 > 2017-05-02
 

--- a/README.md
+++ b/README.md
@@ -22,23 +22,11 @@ yarn add react-transition-group
 
 ## CDN / External
 
-To exclude the react-transition-group package from your primary build and use an external CDN when bundling, link
+Since react-transition-group is fairly small, the overhead of including the library in your application is
+negligible. However, in situations where it may be useful to benefit from an external CDN when bundling, link
 to the following CDN:
 
 [https://unpkg.com/react-transition-group/dist/react-transition-group.min.js](https://unpkg.com/react-transition-group/dist/react-transition-group.min.js)
-
-In order to exclude react-transition-group using **Webpack**, include the following configuration in the `externals`
-webpack configuration section: 
-
-```
-externals: {
-    'react-transition-group': {
-        amd: 'react-transition-group',
-        commonjs2: 'react-transition-group',
-        commonjs: 'react-transition-group',
-        root: 'ReactTransitionGroup',
-    }
-```
 
 ## High-level API: CSSTransitionGroup
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ npm install react-transition-group --save
 yarn add react-transition-group
 ```
 
+## CDN / External
+
+To exclude the react-transition-group package from your primary build and use an external CDN when bundling, link
+to the following CDN:
+
+[https://unpkg.com/react-transition-group/dist/react-transition-group.min.js](https://unpkg.com/react-transition-group/dist/react-transition-group.min.js)
+
+In order to exclude react-transition-group using **Webpack**, include the following configuration in the `externals`
+webpack configuration section: 
+
+```
+externals: {
+    'react-transition-group': {
+        amd: 'react-transition-group',
+        commonjs2: 'react-transition-group',
+        commonjs: 'react-transition-group',
+        root: 'ReactTransitionGroup',
+    }
+```
+
 ## High-level API: CSSTransitionGroup
 
 `CSSTransitionGroup` is a high-level API based on [`TransitionGroup`](#low-level-api-transitiongroup) and is an easy way to perform CSS transitions and animations when a React component enters or leaves the DOM. It's inspired by the excellent [ng-animate](http://www.nganimate.org/) library.
@@ -27,7 +47,7 @@ yarn add react-transition-group
 **Importing**
 
 ```javascript
-import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup' // ES6
+import { CSSTransitionGroup } from 'react-transition-group' // ES6
 
 var CSSTransitionGroup = require('react-transition-group/CSSTransitionGroup') // ES5 with npm
 ```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jest --runInBand --verbose",
     "tdd": "jest --watch",
     "build": "rimraf lib && babel src --out-dir lib && npm run build:dist",
-    "build:dist": "rimraf lib/dist && webpack -p --define process.env.NODE_ENV='production'",
+    "build:dist": "rimraf lib/dist && webpack && NODE_ENV=production webpack -p",
     "lint": "eslint src test",
     "release": "release"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,9 @@ const path = require('path');
 module.exports = {
   entry: './src/index.js',
   output: {
-    filename: 'react-transition-group.js',
+    filename: process.env.NODE_ENV === 'production' 
+      ? 'react-transition-group.min.js'
+      : 'react-transition-group.js',
     path: path.join(__dirname, 'lib/dist'),
     library: 'ReactTransitionGroup',
     libraryTarget: 'umd',


### PR DESCRIPTION
Incorporated development + production builds into /dist (#64) and updated Readme to include CDN/External information.