### PR TITLE
Prevent `this.setState` if there is no component

### DIFF
--- a/index.js
+++ b/index.js
@@ -437,7 +437,7 @@ var TransitionGroup = function (_React$Component) {
       if (currentChildMapping && currentChildMapping.hasOwnProperty(key)) {
         // This entered again before it fully left. Add it again.
         _this.performEnter(key);
-      } else {
+      } else if (component) {
         _this.setState(function (state) {
           var newChildren = Object.assign({}, state.children);
           delete newChildren[key];

--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -174,7 +174,7 @@ class TransitionGroup extends React.Component {
     if (currentChildMapping && currentChildMapping.hasOwnProperty(key)) {
       // This entered again before it fully left. Add it again.
       this.performEnter(key);
-    } else {
+    } else if (component) {
       this.setState((state) => {
         let newChildren = Object.assign({}, state.children);
         delete newChildren[key];


### PR DESCRIPTION
On `_handleDoneLeaving`, prevent calling `setState` if the component is unmounted.

This was triggering this error:

> Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the TransitionGroup component.

This happened on a very complex structure and I was not able to reproduce it with sample code.

It is related to #15.