### PR TITLE
Alternative fix for #55

### DIFF
--- a/test/TransitionGroup-test.js
+++ b/test/TransitionGroup-test.js
@@ -440,4 +440,84 @@ describe('TransitionGroup', () => {
     //   '    in Component (at **)'
     // );
   });
+
+  it('should not throw when enter callback is called and is now leaving', () => {
+    class Child extends React.Component {
+      componentWillReceiveProps() {
+        if (this.callback) {
+          this.callback();
+        }
+      }
+
+      componentWillEnter(callback) {
+        this.callback = callback;
+      }
+
+      render() {
+        return (<span />);
+      }
+    }
+
+    class Component extends React.Component {
+      render() {
+        return (
+          <TransitionGroup>
+            {this.props.children}
+          </TransitionGroup>
+        );
+      }
+    }
+
+    // render the base component
+    ReactDOM.render(<Component />, container);
+    // now make the child enter
+    ReactDOM.render(
+      <Component><Child key="child" /></Component>,
+      container,
+    );
+    // rendering the child leaving will call 'componentWillProps' which will trigger the
+    // callback. This would throw an error previously.
+    expect(ReactDOM.render.bind(this, <Component />, container)).not.toThrow();
+  })
+
+  it('should not throw when leave callback is called and is now entering', () => {
+    class Child extends React.Component {
+      componentWillReceiveProps() {
+        if (this.callback) {
+          this.callback();
+        }
+      }
+
+      componentWillLeave(callback) {
+        this.callback = callback;
+      }
+
+      render() {
+        return (<span />);
+      }
+    }
+
+    class Component extends React.Component {
+      render() {
+        return (
+          <TransitionGroup>
+            {this.props.children}
+          </TransitionGroup>
+        );
+      }
+    }
+
+    // render the base component
+    ReactDOM.render(<Component />, container);
+    // now make the child enter
+    ReactDOM.render(
+      <Component><Child key="child" /></Component>,
+      container,
+    );
+    // make the child leave
+    ReactDOM.render(<Component />, container);
+    // rendering the child entering again will call 'componentWillProps' which will trigger the
+    // callback. This would throw an error previously.
+    expect(ReactDOM.render.bind(this, <Component><Child key="child" /></Component>, container)).not.toThrow();
+  })
 });


### PR DESCRIPTION
This is an alternative to PR #56 addressing issue #55 which seems to have stalled.

I have used the same test @zediah provided and added another one for the 'complementary' error which happens when going in the other direction.

It takes a different approach which is to keep a separate ref for keys which are currently transitioning and use those in the callback function. It also pushes to ```keysToEnter``` when it detects that a component has been re-added while leaving, this enables performEnter to be called in componentDidUpdate after the  ref has been setup.

There may be some situations which are not accounted for but all the tests pass. All feedback is appreciated, many thanks.

