### PR TITLE
Update CSSTransition.js

### DIFF
--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -1,13 +1,14 @@
 import * as PropTypes from 'prop-types';
 import addOneClass from 'dom-helpers/class/addClass';
 
-import removeClass from 'dom-helpers/class/removeClass';
+import removeOneClass from 'dom-helpers/class/removeClass';
 import React from 'react';
 
 import Transition from './Transition';
 import { classNamesShape } from './utils/PropTypes';
 
-const addClass = (node, classes) => classes.split(' ').forEach(c => addOneClass(node, c));
+const addClass = (node, classes) => classes && classes.split(' ').forEach(c => addOneClass(node, c));
+const removeClass = (node, classes) => classes && classes.split(' ').forEach(c => removeOneClass(node, c));
 
 const propTypes = {
   ...Transition.propTypes,


### PR DESCRIPTION
support for removing multiple class names (for use with react-jss)