### PR TITLE
Change how ES6 modules are transpiled

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,6 +9,7 @@
   "plugins": [
     "dev-expression",
     "transform-object-assign",
+    "transform-es2015-modules-commonjs",
     ["transform-react-remove-prop-types", { mode: "wrap" }]
   ],
 }

--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,6 @@
   ],
   "plugins": [
     "dev-expression",
-    "add-module-exports",
     "transform-object-assign",
     ["transform-react-remove-prop-types", { mode: "wrap" }]
   ],

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "babel-eslint": "^7.1.1",
     "babel-jest": "^20.0.3",
     "babel-loader": "^6.4.1",
-    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "babel-jest": "^20.0.3",
     "babel-loader": "^6.4.1",
     "babel-plugin-dev-expression": "^0.2.1",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.5",
     "babel-preset-latest": "^6.24.0",


### PR DESCRIPTION
This seems to be preferred way of transpiling ES6 modules to enable common js imports as well https://babeljs.io/docs/plugins/transform-es2015-modules-commonjs/.

Currently use of `babel-add-export-modules` adds commonjs style `module.exports = exports["default"]` to transpiled files which breaks classic ES6 module imports (they are overwritten by this statement) in some environments such as Typescript. 

Fixes #109, #132