### PR TITLE
docs(Transition): classNames accepts string

### DIFF
--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -32,7 +32,7 @@ const propTypes = {
    * }}
    * ```
    *
-   * @type {{
+   * @type {string | {
    *  appear?: string,
    *  appearActive?: string,
    *  enter?: string,


### PR DESCRIPTION
Transition component accepts a string value.