### PR TITLE
docs(Transition): Fix the Fade transition example

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -32,7 +32,7 @@ export const EXITING = 'exiting';
  * }
  *
  * const transitionStyles = {
- *   entering: { opacity: 1 },
+ *   entering: { opacity: 0 },
  *   entered:  { opacity: 1 },
  * };
  *


### PR DESCRIPTION
The documentation for Transition declares a Fade transition which is supposed to fade the element's opacity to 1, but since the "entering" state was 1, this example doesn't actually fade when run. Changing the "entering" to 0 fixes this.