### PR TITLE
Include LICENSE in build artifact

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest --runInBand --verbose",
     "tdd": "jest --watch",
-    "build": "rimraf lib && babel src --out-dir lib && npm run build:dist && cp README.md ./lib",
+    "build": "rimraf lib && babel src --out-dir lib && npm run build:dist && cp README.md LICENSE ./lib",
     "build:dist": "rimraf lib/dist && webpack && NODE_ENV=production webpack -p",
     "lint": "eslint src test",
     "release": "release",


### PR DESCRIPTION
The version of `react-transition-group` on npm does not include the 
`LICENSE` file and thus tools like `yarn` are not able to generate a 
proper license collection.

To fix this, we should include the license file in the npm package as 
well. This reflects the behavior of other packages like `react`.