### PR TITLE
Workaround issue #216

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -137,7 +137,9 @@ class Transition extends React.Component {
   }
 
   componentDidMount() {
-    this.updateStatus(true);
+    // we do this with setTimeout, so that we are sure that a paint will be done after the initial 'exited' state
+    // without this transitions on mount will not work. See: https://github.com/reactjs/react-transition-group/issues/216
+    setTimeout(() => this.updateStatus(true), 0);
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Extracted the initial transition from EXITED to ENTERING to setTimeout, so that a paint will be done between. Else it is not possible to do CSS transitions, as the browser will not interpret changes to CSS properties as change.