### PR TITLE
Fix CSSTransition codesandbox example

### DIFF
--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -103,6 +103,7 @@ const propTypes = {
  * When the `in` prop is toggled to `true` the Component will get
  * the `example-enter` CSS class and the `example-enter-active` CSS class
  * added in the next tick. This is a convention based on the `classNames` prop.
+ *
  * <iframe src="https://codesandbox.io/embed/kw8z6pp9zo?autoresize=1&fontsize=12&hidenavigation=1&moduleview=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
  */
 class CSSTransition extends React.Component {

--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -103,8 +103,7 @@ const propTypes = {
  * When the `in` prop is toggled to `true` the Component will get
  * the `example-enter` CSS class and the `example-enter-active` CSS class
  * added in the next tick. This is a convention based on the `classNames` prop.
- *
- * <iframe src="https://codesandbox.io/embed/yv645oq21x?autoresize=1&fontsize=12&hidenavigation=1&moduleview=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+ * <iframe src="https://codesandbox.io/embed/kw8z6pp9zo?autoresize=1&fontsize=12&hidenavigation=1&moduleview=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
  */
 class CSSTransition extends React.Component {
   onEnter = (node, appearing) => {


### PR DESCRIPTION
The existing example codesandbox for the CSSTransition component doesn't properly hide the `div`. The `div` fades out, then reappears without a transition, as soon as it's done fading out. I updated the example to include the `unmountOnExit` prop, so it properly shows and hides the `div`.

Existing:
https://codesandbox.io/embed/yv645oq21x

New:
https://codesandbox.io/embed/kw8z6pp9zo