### PR TITLE
render only children with component=null

### DIFF
--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -179,15 +179,18 @@ class TransitionGroup extends React.Component {
 
   render() {
     const { component: Component, childFactory, ...props } = this.props;
-    const { children } = this.state;
+    const children = values(this.state.children).map(childFactory);
 
     delete props.appear;
     delete props.enter;
     delete props.exit;
 
+    if (Component === null) {
+      return children;
+    }
     return (
       <Component {...props}>
-        {values(children).map(childFactory)}
+        {children}
       </Component>
     );
   }

--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -8,7 +8,10 @@ const values = Object.values || (obj => Object.keys(obj).map(k => obj[k]));
 const propTypes = {
   /**
    * `<TransitionGroup>` renders a `<div>` by default. You can change this
-   * behavior by providing a `component` prop.
+   * behavior by providing a `component` prop. 
+   * If you use React v16+ and would like to avoid a wrapping `<div>` element
+   * you can pass in `component={null}`. This is useful if the wrapping div
+   * borks your css styles.
    */
   component: PropTypes.any,
   /**

--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -8,7 +8,7 @@ const values = Object.values || (obj => Object.keys(obj).map(k => obj[k]));
 const propTypes = {
   /**
    * `<TransitionGroup>` renders a `<div>` by default. You can change this
-   * behavior by providing a `component` prop. 
+   * behavior by providing a `component` prop.
    * If you use React v16+ and would like to avoid a wrapping `<div>` element
    * you can pass in `component={null}`. This is useful if the wrapping div
    * borks your css styles.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5773,11 +5773,19 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.5.8, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0:
+prop-types@15.5.8, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
     fbjs "^0.8.9"
+
+prop-types@^15.5.10, prop-types@^15.5.9, prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 proxy-addr@~2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Fixes #242 

Usage:
```
<TransitionGroup component={null}>
  <div style={{width: '100%'}}></div>
</TransitionGroup>
```

I'd love to see this become the default behavior. TransitionGroup is a container, and probably shouldn't modify the DOM. With React 16, now we don't have to.