### PR TITLE
Fix "Uncaught TypeError: Cannot read property 'classList' of null"

### DIFF
--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -7,8 +7,8 @@ import React from 'react';
 import Transition from './Transition';
 import { classNamesShape } from './utils/PropTypes';
 
-const addClass = (node, classes) => classes && classes.split(' ').forEach(c => addOneClass(node, c));
-const removeClass = (node, classes) => classes && classes.split(' ').forEach(c => removeOneClass(node, c));
+const addClass = (node, classes) => node && classes && classes.split(' ').forEach(c => addOneClass(node, c));
+const removeClass = (node, classes) => node && classes && classes.split(' ').forEach(c => removeOneClass(node, c));
 
 const propTypes = {
   ...Transition.propTypes,
@@ -190,7 +190,7 @@ class CSSTransition extends React.Component {
     // This is for to force a repaint,
     // which is necessary in order to transition styles when adding a class name.
     /* eslint-disable no-unused-expressions */
-    node.scrollTop;
+    node && node.scrollTop;
     /* eslint-enable no-unused-expressions */
     addClass(node, className);
   }

--- a/test/CSSTransitionGroup-test.js
+++ b/test/CSSTransitionGroup-test.js
@@ -119,6 +119,28 @@ describe('CSSTransitionGroup', () => {
     );
   });
 
+  it('should work with a child which renders as null', () => {
+    const NullComponent = () => null;
+    // Testing the whole lifecycle of entering and exiting,
+    // because those lifecycle methods used to fail when the DOM node was null.
+    ReactDOM.render(
+      <TransitionGroup/>,
+      container,
+    );
+    ReactDOM.render(
+      <TransitionGroup>
+        <CSSTransition classNames="yolo" timeout={0}>
+          <NullComponent/>
+        </CSSTransition>
+      </TransitionGroup>,
+      container,
+    );
+    ReactDOM.render(
+      <TransitionGroup/>,
+      container,
+    );
+  });
+
   it('should transition from one to null', () => {
     let a = ReactDOM.render(
       <TransitionGroup>


### PR DESCRIPTION
This is a fix for issue #208 

This fix has also been published at https://www.npmjs.com/package/@luontola/react-transition-group as 2.3.0-patch.3