### PR TITLE
Modify code syntax highlight for css-transition page

### DIFF
--- a/css-transition/index.html
+++ b/css-transition/index.html
@@ -34,10 +34,10 @@ Each individual classNames can also be specified independently like:</p>
  appearActive<span class="token punctuation">:</span> <span class="token string">'my-active-appear'</span><span class="token punctuation">,</span>
  enter<span class="token punctuation">:</span> <span class="token string">'my-enter'</span><span class="token punctuation">,</span>
  enterActive<span class="token punctuation">:</span> <span class="token string">'my-active-enter'</span><span class="token punctuation">,</span>
- enterDone<span class="token punctuation">:</span> 'my<span class="token operator">-</span>done<span class="token operator">-</span>enter<span class="token punctuation">,</span>
+ enterDone<span class="token punctuation">:</span> <span class="token string">'my-done-enter'</span><span class="token punctuation">,</span>
  exit<span class="token punctuation">:</span> <span class="token string">'my-exit'</span><span class="token punctuation">,</span>
  exitActive<span class="token punctuation">:</span> <span class="token string">'my-active-exit'</span><span class="token punctuation">,</span>
- exitDone<span class="token punctuation">:</span> 'my<span class="token operator">-</span>done<span class="token operator">-</span>exit<span class="token punctuation">,</span>
+ exitDone<span class="token punctuation">:</span> <span class="token string">'my-done-exit'</span><span class="token punctuation">,</span>
 <span class="token punctuation">}</span><span class="token punctuation">}</span>
 </code></pre>
       </div></div><div style="padding-left:0;" data-reactid="36"><div data-reactid="37"><!-- react-text: 38 -->type: <!-- /react-text --><code data-reactid="39">string | {


### PR DESCRIPTION
I modified code syntax highlight for `classNames` part in CSS Transition page.
`my-done-enter` and `my-exit-done` are broken.
Thank you 👍 
Ref: http://reactcommunity.org/react-transition-group/css-transition#CSSTransition-prop-classNames

## Screenshots

|before|after|
|:-:|:-:|
|![image](https://user-images.githubusercontent.com/4658938/39604927-2f8eeb0e-4f69-11e8-90b7-672103a44265.png)|![image](https://user-images.githubusercontent.com/4658938/39604934-3c557858-4f69-11e8-9c78-be1f1d511ad6.png)|

- - -

I followed past commit messages (`Updates`) for now.
I can change it if you want.