### PR TITLE
updated dom-helpers from 3.2.0 to 3.3.1 due a bug known crashing in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "chain-function": "^1.0.0",
-    "dom-helpers": "^3.2.0",
+    "dom-helpers": "^3.3.1",
     "loose-envify": "^1.3.1",
     "prop-types": "^15.5.6",
     "warning": "^3.0.0"


### PR DESCRIPTION
update: 
I changed the PR (force-push) from 3.2.1 to 3.3.1 because the dom-helpers author wrongly tagged the version.