### PR TITLE
chore: clone last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ cache: yarn
 script:
   - commitlint-travis
   - yarn test
-
+git:
+  depth: 5
 after_success:
   - npm run build
   - npm run semantic-release


### PR DESCRIPTION
By default Travis clones the last 50 commits. 5 are sufficient and typically faster.

See https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth