### PR TITLE
Dont add invalid props to html elements

### DIFF
--- a/src/utils/ChildMapping.js
+++ b/src/utils/ChildMapping.js
@@ -87,6 +87,8 @@ function getProp(child, prop, props) {
 
 export function getInitialChildMapping(props, onExited) {
   return getChildMapping(props.children, child => {
+    if (typeof child.type === 'string') return cloneElement(child)
+
     return cloneElement(child, {
       onExited: onExited.bind(null, child),
       in: true,

--- a/test/TransitionGroup-test.js
+++ b/test/TransitionGroup-test.js
@@ -72,6 +72,18 @@ describe('TransitionGroup', () => {
     ReactDOM.render(<TransitionGroup />, container)
   })
 
+  it('should work with html tag as child', () => {
+    console.error = jest.fn()
+    ReactDOM.render(
+      <TransitionGroup>
+        <span>foo</span>
+      </TransitionGroup>,
+      container
+    )
+    expect(console.error).not.toHaveBeenCalled()
+    console.error.mockRestore()
+  })
+
   it('should handle transitioning correctly', () => {
     function Parent({ count = 1 }) {
       let children = []


### PR DESCRIPTION
When there is html tag as children of `TransitionGroup` before any other component it will throw error:
```
Warning: Unknown props `onExited`, `appear`, `enter`, `exit` on <div> tag. 
Remove these props from the element. For details, see https://fb.me/react-unknown-prop
```
I think its a valid usecase to have html tags before `CSSTransition` or any other component so this fixes it. I dont see also anywhere in documentation that `CSSTransition` must come before any html tag.