### PR TITLE
Throw more descriptive error if no classNames prop

### DIFF
--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -192,25 +192,23 @@ class CSSTransition extends React.Component {
 
   getClassNames = (type) => {
     const { classNames } = this.props;
-    
     let activeClassName;
     let className;
     let doneClassName;
     switch(typeof classNames) {
-      case "string":
+      case 'string':
         className = classNames + '-' + type;
         activeClassName = className + '-active';
         doneClassName = className + '-done';
         break;
-      case "object":
+      case 'object':
         className = classNames[type];
         activeClassName = classNames[type + 'Active'];
         doneClassName = classNames[type + 'Done'];
         break;
       default:
-        throw new ReferenceError(`classNames must be of type object or string, got ${typeof classNames}`);
+        throw new ReferenceError('classNames must be of type object or string, got ' + typeof classNames);
     }
-    
     return {
       className,
       activeClassName,

--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -192,16 +192,25 @@ class CSSTransition extends React.Component {
 
   getClassNames = (type) => {
     const { classNames } = this.props;
-
-    let className = typeof classNames !== 'string' ?
-      classNames[type] : classNames + '-' + type;
-
-    let activeClassName = typeof classNames !== 'string' ?
-      classNames[type + 'Active'] : className + '-active';
-
-    let doneClassName = typeof classNames !== 'string' ?
-      classNames[type + 'Done'] : className + '-done';
-
+    
+    let activeClassName;
+    let className;
+    let doneClassName;
+    switch(typeof classNames) {
+      case "string":
+        className = classNames + '-' + type;
+        activeClassName = className + '-active';
+        doneClassName = className + '-done';
+        break;
+      case "object":
+        className = classNames[type];
+        activeClassName = classNames[type + 'Active'];
+        doneClassName = classNames[type + 'Done'];
+        break;
+      default:
+        throw new ReferenceError(`classNames must be of type object or string, got ${typeof classNames}`);
+    }
+    
     return {
       className,
       activeClassName,


### PR DESCRIPTION
The error currently shown if `classNames` is not specified is not helpful. The way this function is written assumes that if it's not a string, it must be an object, which may not be the case if `this.props.className` is undefined. Now, a `ReferenceError` is thrown if `classNames` is not specified at all.