### PR TITLE
Don't use string refs in tests

### DIFF
--- a/test/Transition-test.js
+++ b/test/Transition-test.js
@@ -264,7 +264,7 @@ describe('Transition', () => {
 
         return (
           <Transition
-            ref="transition"
+            ref={transition => this.transition = this.transition || transition}
             mountOnEnter
             in={this.state.in}
             timeout={10}
@@ -276,7 +276,7 @@ describe('Transition', () => {
       }
 
       getStatus = () => {
-        return this.refs.transition.state.status
+        return this.transition.state.status
       }
     }
 
@@ -337,7 +337,7 @@ describe('Transition', () => {
 
         return (
           <Transition
-            ref="transition"
+            ref={transition => this.transition = this.transition || transition}
             unmountOnExit
             in={this.state.in}
             timeout={10}
@@ -349,7 +349,7 @@ describe('Transition', () => {
       }
 
       getStatus = () => {
-        return this.refs.transition.state.status
+        return this.transition.state.status
       }
     }
 


### PR DESCRIPTION
This PR replaces string refs with function refs. Those functions retain the instance after the unmount to allow for verification of the `status`.

I was asked to separate this PR from the Context upgrade PR: https://github.com/reactjs/react-transition-group/pull/427#discussion_r247799518

This is an unimportant change. I think the priority for react-transition-group should be to update to the new Context API to avoid bugs caused by the legacy API: https://github.com/reactjs/react-transition-group/pull/427