### PR TITLE
better docs for TransitionGroup about use of `key` prop on children

### DIFF
--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -122,6 +122,10 @@ TransitionGroup.propTypes = {
    * leave. the `<TransitionGroup>` will inject specific transition props, so
    * remember to spread them through if you are wrapping the `<Transition>` as
    * with our `<Fade>` example.
+   *
+   * Also make sure your `<Transition>` children have a unique `key` prop even
+   * if you're just rendering one, otherwise `TransitionGroup` won't know
+   * when it's time to mount one and unmount the other.
    */
   children: PropTypes.node,
 

--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -123,9 +123,12 @@ TransitionGroup.propTypes = {
    * remember to spread them through if you are wrapping the `<Transition>` as
    * with our `<Fade>` example.
    *
-   * Also make sure your `<Transition>` children have a unique `key` prop even
-   * if you're just rendering one, otherwise `TransitionGroup` won't know
-   * when it's time to mount one and unmount the other.
+   * While this component is meant to make it easier to animate multiple
+   * `Transition` or `CSSTransition` children, sometimes you want to transition a
+   * single child by changing its content, e.g. routes, slides, images in a
+   * carousel etc. In that case you can change the `key` prop of the child
+   * component along with its content, that way `TransitionGroup` will know that
+   * it should transition the child.
    */
   children: PropTypes.node,
 


### PR DESCRIPTION
## Fixes #466 

You don't always have the children of `TransitionGroup` mapped sometimes you want to render one at a time (eg image carousel) so it took me a while to figure out they need to have a `key` prop even when just rendering a single one by going to the source and reading this:

https://github.com/reactjs/react-transition-group/blob/master/src/utils/ChildMapping.js#L3-L19

So now im sending this PR with those insights so its easier for people to know about this

I made a small working example with styled-components

https://github.com/shelldandy/styled-transitions-example/blob/master/pages/index.js#L115-L121