### PR TITLE
fix(package.json): mark react-transition-group as side-effect free for webpack tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,5 +123,6 @@
     "transform": [
       "loose-envify"
     ]
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
## What
Add `"sideEffects": false` to `package.json` to hint to `webpack` based workflows that the package is side effect free. This allows `react-transition-group` to allow tree-shaking of its modules.

Reference: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free