### PR TITLE
Remove react-lifecycles-compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
   "dependencies": {
     "dom-helpers": "^3.4.0",
     "loose-envify": "^1.4.0",
-    "prop-types": "^15.6.2",
-    "react-lifecycles-compat": "^3.0.4"
+    "prop-types": "^15.6.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.3",

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -1,7 +1,6 @@
 import * as PropTypes from 'prop-types'
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { polyfill } from 'react-lifecycles-compat'
 
 import { timeoutsShape } from './utils/PropTypes'
 import TransitionGroupContext from './TransitionGroupContext'
@@ -546,4 +545,4 @@ Transition.ENTERING = 2
 Transition.ENTERED = 3
 Transition.EXITING = 4
 
-export default polyfill(Transition)
+export default Transition

--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { polyfill } from 'react-lifecycles-compat'
 import TransitionGroupContext from './TransitionGroupContext'
-
 
 import {
   getChildMapping,
@@ -169,4 +167,4 @@ TransitionGroup.propTypes = {
 
 TransitionGroup.defaultProps = defaultProps
 
-export default polyfill(TransitionGroup)
+export default TransitionGroup


### PR DESCRIPTION
React >=16.6.0 is a peer dependency of the project. [react-lifecycles-compat](https://github.com/reactjs/react-lifecycles-compat) brings the support of legacy lifecycle for React versions between [0.14.9, 16.3.0[. It's no longer needed.

A non-negligible win https://bundlephobia.com/result?p=react-lifecycles-compat@3.0.4 :)