### PR TITLE
Documentation-fix for the child-function state

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -373,7 +373,7 @@ Transition.propTypes = {
   /**
    * A `function` child can be used instead of a React element. This function is
    * called with the current transition status (`'entering'`, `'entered'`,
-   * `'exiting'`, `'exited'`, `'unmounted'`), which can be used to apply context
+   * `'exiting'`, `'exited'`), which can be used to apply context
    * specific props to a component.
    *
    * ```jsx


### PR DESCRIPTION
The child-function is never called with a state of 'unmounted', since `render()` bails early in that case.