### PR TITLE
fix: adds missing dependency @babel/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dom": ">=16.6.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.4.5"
+    "@babel/runtime": "^7.4.5",
     "dom-helpers": "^3.4.0",
     "loose-envify": "^1.4.0",
     "prop-types": "^15.6.2"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-dom": ">=16.6.0"
   },
   "dependencies": {
+    "@babel/runtime": "^7.4.5"
     "dom-helpers": "^3.4.0",
     "loose-envify": "^1.4.0",
     "prop-types": "^15.6.2"


### PR DESCRIPTION
Using yarn with pnp enabled enforces a correct dependency structure. While using any module that has this package as a dependency I get the following error:

```
ERROR in /home/msilva/.cache/yarn/v4/npm-react-transition-group-4.1.0-7b50c0a93a6c127336187252c3c1a70eff3304ce/node_modules/react-transition-group/esm/CSSTransition.js
Module not found: Error: Package "react-transition-group@4.1.0" (via "/home/msilva/.cache/yarn/v4/npm-react-transition-group-4.1.0-7b50c0a93a6c127336187252c3c1a70eff3304ce/node_modules/react-transition-group/esm/CSSTransition.js") is trying to require the package "@babel/runtime" (via "@babel/runtime/helpers/esm/extends") without it being listed in its dependencies (react, react-dom, dom-helpers, loose-envify, prop-types, react-transition-group)
 @ /home/msilva/.cache/yarn/v4/npm-react-transition-group-4.1.0-7b50c0a93a6c127336187252c3c1a70eff3304ce/node_modules/react-transition-group/esm/CSSTransition.js 1:0-58 228:43-51
 @ /home/msilva/.cache/yarn/v4/npm-react-transition-group-4.1.0-7b50c0a93a6c127336187252c3c1a70eff3304ce/node_modules/react-transition-group/esm/index.js
 @ /home/msilva/.cache/yarn/v4/npm-@material-ui-core-4.0.2-c7a07c1d1b13b94adf479d7267b51cb682fcb279/node_modules/@material-ui/core/Slide/Slide.js
```

to fix this I added the latest version of @babel/runtime to the dependencies.
