### PR TITLE
docs: Add anchor for props section

### DIFF
--- a/www/src/templates/component.js
+++ b/www/src/templates/component.js
@@ -73,8 +73,8 @@ class ComponentTemplate extends React.Component {
           )}
 
           <Container>
-            <h2>
-              <div>Props</div>
+            <h2 id={`${metadata.displayName}-props`}>
+              <a href={`#${metadata.displayName}-props`}>Props</a>
               {metadata.composes && (
                 <small style={{ fontStyle: 'italic', fontSize: '70%' }}>
                   Accepts all props from{' '}


### PR DESCRIPTION
Adds an anchor to the props section in addition to the existing anchors for each individual prop.