### PR TITLE
Ensure SwitchTransition component is exported

### DIFF
--- a/src/SwitchTransition.js
+++ b/src/SwitchTransition.js
@@ -96,7 +96,7 @@ const enterRenders = {
  * }
  * ```
  */
-export class SwitchTransition extends React.Component {
+class SwitchTransition extends React.Component {
   state = {
     status: ENTERED,
     current: null
@@ -189,3 +189,5 @@ SwitchTransition.propTypes = {
 SwitchTransition.defaultProps = {
   mode: modes.out
 }
+
+export default SwitchTransition;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export { default as CSSTransition } from './CSSTransition'
 export { default as ReplaceTransition } from './ReplaceTransition'
+export { default as SwitchTransition } from './SwitchTransition'
 export { default as TransitionGroup } from './TransitionGroup'
 export { default as Transition } from './Transition'
 export { default as config } from './config'

--- a/test/SwitchTransition-test.js
+++ b/test/SwitchTransition-test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import Transition, { ENTERED } from '../src/Transition';
-import { SwitchTransition, modes } from '../src/SwitchTransition';
+import SwitchTransition, { modes } from '../src/SwitchTransition';
 
 describe('SwitchTransition', () => {
   let log, Parent;


### PR DESCRIPTION
**Issue:**
New `SwitchTransition` component isn't exported from `src/index.js` and cannot be used unless imported directly.

**Fix:**
Added export of `SwitchTransition` from `src/index.js`. Also updated export of `SwitchTransition` to be default export, with other exports being named exports, following the convention of the other components.
