### PR TITLE
added transition status parameter to addEndListener prop

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -319,7 +319,7 @@ class Transition extends React.Component {
     }
 
     if (this.props.addEndListener) {
-      this.props.addEndListener(node, this.nextCallback)
+      this.props.addEndListener(node, this.nextCallback, this.state.status)
     }
 
     if (timeout != null) {


### PR DESCRIPTION
like discussed in #519 I passed down the `status` as a parameter to `addEndListener`, so when using SwitchTransition with javascript animations for dynamic components (which don't have a `show` variable) the addEndListener prop can decide which animation to run based on the current status. `exiting` or `entering` is being passed down in the following example:

```jsx
<SwitchTransition mode={ "out-in" }>
  <Transition
    key={ questionObject.id + "loool" }
    addEndListener={ (node, done, status) =>  {
        if (status === "exiting") {
          // dont know why, but the return seems necessary
          return TweenMax.to(node, 2, { yPercent: 100, onComplete: done })
        }
        if (status === "entering")
          return TweenMax.from(node, 2, { yPercent: 100, clearProps: "all", onComplete: done })
      }
    }
  >
    <Question
      questionObject={ questionObject }
      onChange={ (value) => setAnswer(currentQuestionId, value) }
    />
  </Transition>
</SwitchTransition>
```