### PR TITLE
Improve JSDoc in SwitchTransition

### DIFF
--- a/src/SwitchTransition.js
+++ b/src/SwitchTransition.js
@@ -76,23 +76,24 @@ const enterRenders = {
  * Based on the selected mode and the child's key which is the `Transition` or `CSSTransition` component, the `SwitchTransition` makes a consistent transition between them.
  *
  * If the `out-in` mode is selected, the `SwitchTransition` waits until the old child leaves and then inserts a new child.
- * If the `in-out` mode is selected, the `SwitchTransition` inserts a new child first, waits for the new child to enter and then removes the old child
+ * If the `in-out` mode is selected, the `SwitchTransition` inserts a new child first, waits for the new child to enter and then removes the old child.
  *
  * ```jsx
- *
  * function App() {
- *  const [state, setState] = useState(false);
- *  return (
- *    <SwitchTransition>
- *      <FadeTransition key={state ? "Goodbye, world!" : "Hello, world!"}
- *        addEndListener={(node, done) => node.addEventListener("transitionend", done, false)}
- *        classNames='fade' >
- *        <button onClick={() => setState(state => !state)}>
- *          {state ? "Goodbye, world!" : "Hello, world!"}
- *        </button>
- *      </FadeTransition>
- *    </SwitchTransition>
- *  )
+ *   const [state, setState] = useState(false);
+ *   return (
+ *     <SwitchTransition>
+ *       <FadeTransition
+ *         key={state ? "Goodbye, world!" : "Hello, world!"}
+ *         addEndListener={(node, done) => node.addEventListener("transitionend", done, false)}
+ *         classNames='fade'>
+ *       >
+ *         <button onClick={() => setState(state => !state)}>
+ *           {state ? "Goodbye, world!" : "Hello, world!"}
+ *         </button>
+ *       </FadeTransition>
+ *     </SwitchTransition>
+ *   );
  * }
  * ```
  */
@@ -173,13 +174,13 @@ SwitchTransition.propTypes = {
   /**
    * Transition modes.
    * `out-in`: Current element transitions out first, then when complete, the new element transitions in.
-   * `in-out: New element transitions in first, then when complete, the current element transitions out.`
+   * `in-out`: New element transitions in first, then when complete, the current element transitions out.
    *
    * @type {'out-in'|'in-out'}
    */
   mode: PropTypes.oneOf([modes.in, modes.out]),
   /**
-   * Any `Transition` or `CSSTransition` component
+   * Any `Transition` or `CSSTransition` component.
    */
   children: PropTypes.oneOfType([
     PropTypes.element.isRequired,


### PR DESCRIPTION
Hi, the new component `<SwitchTransition>` since v4.2.0 is so nice!

I find some small mistakes about JSDoc in the component, so I open this PR.

Summary:
- Add missing periods.
- Fix a backquote.
- Format a code example.

It would be great if you could check it. Thanks.
