### PR TITLE
fix(readme): add guidance on TypeScript in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ A set of components for managing component states (including mounting and unmoun
 - [**Main documentation**](https://reactcommunity.org/react-transition-group/)
 - [Migration guide from v1](/Migration.md)
 
+## TypeScript
+TypeScript definitions are published via [**DefinitelyTyped**](https://github.com/DefinitelyTyped/DefinitelyTyped) and can be installed via the following command:
+
+```
+npm install @types/react-transition-group
+```
+
 ## Examples
 
 Clone the repo first:


### PR DESCRIPTION
## Description
Adds a short section about TypeScript to the README.md, to provide guidance to users who may be using TypeScript in their projects.

### To-do
There could be a section added about `flow-typed`, though I am unfamiliar with that particular workflow.