### PR TITLE
SwitchTransition children may be equal if both keys are null

### DIFF
--- a/src/SwitchTransition.js
+++ b/src/SwitchTransition.js
@@ -8,8 +8,7 @@ function areChildrenDifferent(oldChildren, newChildren) {
   if (
     React.isValidElement(oldChildren) &&
     React.isValidElement(newChildren) &&
-    oldChildren.key != null &&
-    oldChildren.key === newChildren.key
+    ((oldChildren.key == null && newChildren.key == null) || oldChildren.key === newChildren.key)
   ) {
     return false;
   }

--- a/test/SwitchTransition-test.js
+++ b/test/SwitchTransition-test.js
@@ -43,6 +43,18 @@ describe('SwitchTransition', () => {
     expect(wrapper.state('status')).toBe(ENTERED);
   });
 
+  it('should have default status ENTERED', () => {
+    const wrapper = mount(
+      <SwitchTransition>
+        <Transition timeout={0} key=null>
+          <span />
+        </Transition>
+      </SwitchTransition>
+    );
+
+    expect(wrapper.state('status')).toBe(ENTERED);
+  });
+
   it('should have default mode: out-in', () => {
     const wrapper = mount(
       <SwitchTransition>


### PR DESCRIPTION
If the SwitchTransition's children both have a null key then they were not equal. If the Router's location has no key then the children were being continually re-rendered with the animation applied.