### PR TITLE
fix: Fix imports to play nicely with rollup

### DIFF
--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -1,4 +1,4 @@
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import addOneClass from 'dom-helpers/class/addClass';
 
 import removeOneClass from 'dom-helpers/class/removeClass';

--- a/src/ReplaceTransition.js
+++ b/src/ReplaceTransition.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { findDOMNode } from 'react-dom'
+import ReactDOM from 'react-dom'
 import TransitionGroup from './TransitionGroup';
 
 /**
@@ -28,7 +28,7 @@ class ReplaceTransition extends React.Component {
     const child = React.Children.toArray(children)[idx];
 
     if (child.props[handler]) child.props[handler](...originalArgs)
-    if (this.props[handler]) this.props[handler](findDOMNode(this))
+    if (this.props[handler]) this.props[handler](ReactDOM.findDOMNode(this))
   }
 
   render() {

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -1,4 +1,4 @@
-import * as PropTypes from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import ReactDOM from 'react-dom'
 


### PR DESCRIPTION
Fixes #529, and a similar issues with `ReactDOM.findDOMNode()`

**Before** this change, I was getting errors with rolllup such as:
```
(!) Missing exports
https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-
../react-transition-group/lib/esm/Transition.js
oneOfType is not exported by ../react-transition-group/node_modules/prop-types/index.js
419:    * ```
420:    */
421:   children: PropTypes.oneOfType([PropTypes.func.isRequired, PropTypes.element.isRequired]).isRequired,
                           ^
422:
423:   /**
```
and
```
[!] Error: 'findDOMNode' is not exported by ../react-transition-group/node_modules/react-dom/index.js
https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-
../react-transition-group/lib/esm/ReplaceTransition.js (5:9)
3: import PropTypes from 'prop-types';
4: import React from 'react';
5: import { findDOMNode } from 'react-dom';
            ^
6: import TransitionGroup from './TransitionGroup';
7: /**
Error: 'findDOMNode' is not exported by ../react-transition-group/node_modules/react-dom/index.js
    at error (/Users/bencentra/toast/git-repos/buffet/node_modules/rollup/dist/rollup.js:3598:30)
    at Module.error (/Users/bencentra/toast/git-repos/buffet/node_modules/rollup/dist/rollup.js:14473:9)
    at handleMissingExport (/Users/bencentra/toast/git-repos/buffet/node_modules/rollup/dist/rollup.js:14400:21)
    at Module.traceVariable (/Users/bencentra/toast/git-repos/buffet/node_modules/rollup/dist/rollup.js:14742:17)
    at ModuleScope.findVariable (/Users/bencentra/toast/git-repos/buffet/node_modules/rollup/dist/rollup.js:13444:37)
    at FunctionScope.ChildScope.findVariable (/Users/bencentra/toast/git-repos/buffet/node_modules/rollup/dist/rollup.js:4281:67)
    at ChildScope.findVariable (/Users/bencentra/toast/git-repos/buffet/node_modules/rollup/dist/rollup.js:4281:67)
    at FunctionScope.ChildScope.findVariable (/Users/bencentra/toast/git-repos/buffet/node_modules/rollup/dist/rollup.js:4281:67)
    at ChildScope.findVariable (/Users/bencentra/toast/git-repos/buffet/node_modules/rollup/dist/rollup.js:4281:67)
    at Identifier.bind (/Users/bencentra/toast/git-repos/buffet/node_modules/rollup/dist/rollup.js:11247:40)
```

**After** this change, I can run my project's rollup successfully (`$ NODE_ENV=production rollup -c`)

Tested locally by `yarn link`-ing `react-transition-group` to my project and running `yarn build` before building my own project.

I don't know exactly what (if anything) changed with this package that would've caused these issues, since the lines I'm changing are over a year old. `react-dom` got updated 2 days ago, `prop-types` 6 months ago, and `rollup` yesterday. Maybe it's a rollup problem?