### PR TITLE
fix: appearing animation with Transition

### DIFF
--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -6,6 +6,7 @@ import React from 'react';
 
 import Transition from './Transition';
 import { classNamesShape } from './utils/PropTypes';
+import { reflow } from './utils/dom';
 
 const addClass = (node, classes) => node && classes && classes.split(' ').forEach(c => addOneClass(node, c));
 const removeClass = (node, classes) => node && classes && classes.split(' ').forEach(c => removeOneClass(node, c));
@@ -173,11 +174,9 @@ class CSSTransition extends React.Component {
       className += ` ${this.getClassNames('enter').doneClassName}`;
     }
 
-    // This is for to force a repaint,
-    // which is necessary in order to transition styles when adding a class name.
     if (phase === 'active') {
-      /* eslint-disable no-unused-expressions */
-      node && node.scrollTop;
+      // This is necessary to apply transition styles when adding a class name.
+      reflow(node)
     }
 
     this.appliedClasses[type][phase] = className

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -167,9 +167,11 @@ class Transition extends React.Component {
   // }
 
   componentDidMount() {
-    const node = ReactDOM.findDOMNode(this)
     // This is necessary to make a transition happen
-    reflow(node)
+    if (this.appearStatus === ENTERING) {
+      const node = ReactDOM.findDOMNode(this)
+      reflow(node)
+    }
     this.updateStatus(true, this.appearStatus)
   }
 

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -190,6 +190,12 @@ class Transition extends React.Component {
         }
       }
     }
+    // if mountOnEnter is true, this is the time that children is mounted.
+    // so we have to trigger reflow the same as cDM
+    if (this.props.mountOnEnter && nextStatus === ENTERING) {
+      const node = ReactDOM.findDOMNode(this)
+      reflow(node)
+    }
     this.updateStatus(false, nextStatus)
   }
 

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom'
 
 import config from './config'
 import { timeoutsShape } from './utils/PropTypes'
+import { reflow } from './utils/dom'
 import TransitionGroupContext from './TransitionGroupContext'
 
 export const UNMOUNTED = 'unmounted'
@@ -166,6 +167,9 @@ class Transition extends React.Component {
   // }
 
   componentDidMount() {
+    const node = ReactDOM.findDOMNode(this)
+    // This is necessary to make a transition happen
+    reflow(node)
     this.updateStatus(true, this.appearStatus)
   }
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,0 +1,4 @@
+export const reflow = (node) => {
+  /* eslint-disable no-unused-expressions */
+  node && node.scrollTop;
+}

--- a/stories/Transition.js
+++ b/stories/Transition.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
+import Transition, { ENTERED, ENTERING } from '../src/Transition';
 import { Fade, Collapse } from './transitions/Bootstrap'
 import StoryFixture from './StoryFixture'
 
@@ -51,3 +52,35 @@ storiesOf('Transition', module)
       </Collapse>
     </ToggleFixture>
   ))
+  .add('Appearing Animation', () => {
+    const duration = 300;
+    const defaultStyle = {
+      position: 'absolute',
+      transition: `left ${duration}ms ease-in-out`,
+      left: 0,
+    };
+
+     const transitionStyles = {
+      [ENTERING]: { left: '50%' },
+      [ENTERED]: { left: '50%' },
+    };
+
+     return (
+      <Transition
+      in={true}
+      appear={true}
+      timeout={duration}
+    >
+      {state => (
+          <div
+            style={{
+              ...defaultStyle,
+              ...transitionStyles[state],
+            }}
+          >
+            This is an appearing animation
+          </div>
+      )}
+    </Transition>
+    )
+  })

--- a/stories/Transition.js
+++ b/stories/Transition.js
@@ -41,6 +41,13 @@ storiesOf('Transition', module)
       </Fade>
     </ToggleFixture>
   ))
+  .add('Bootstrap Fadelazy mounting', () => (
+    <ToggleFixture>
+      <Fade mountOnEnter unmountOnExit>
+        <div>asaghasg asgasg</div>
+      </Fade>
+    </ToggleFixture>
+  ))
   .add('Bootstrap Collapse', () => (
     <ToggleFixture>
       <Collapse>


### PR DESCRIPTION
This fixes #538.
Currently, changing `appearing` status is synchronously on cDM, so transitions never been applied.
The following is a minimum case for that.

https://codepen.io/koba04/pen/JjPKmMw

So I've added a reflow before the transition as well as CSSTransition.