### PR TITLE
import style dom-helper from 'dom-helpers/css' instead of 'dom-helpers/style' 

### DIFF
--- a/stories/transitions/Bootstrap.js
+++ b/stories/transitions/Bootstrap.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import style from 'dom-helpers/style';
+import style from 'dom-helpers/css';
 
 import Transition, { EXITED, ENTERED, ENTERING, EXITING }
   from '../../src/Transition';


### PR DESCRIPTION
Currently when running `npm run storybook` I get this compilation error:
```
ERROR in ./stories/transitions/Bootstrap.js
Module not found: Error: Can't resolve 'dom-helpers/style'
```

This is fixed by changing the import statement to import from `dom-helpers/css` instead of `dom-helpers/style`.