### PR TITLE
Fix Transition constants to match

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -544,10 +544,10 @@ Transition.defaultProps = {
   onExited: noop,
 }
 
-Transition.UNMOUNTED = 0
-Transition.EXITED = 1
-Transition.ENTERING = 2
-Transition.ENTERED = 3
-Transition.EXITING = 4
+Transition.UNMOUNTED = UNMOUNTED
+Transition.EXITED = EXITED
+Transition.ENTERING = ENTERING
+Transition.ENTERED = ENTERED
+Transition.EXITING = EXITING
 
 export default Transition


### PR DESCRIPTION
Ran into a bug while using `react-bootstrap` and traced the root cause back here.

`react-bootstrap` is importing the different constants in their source code as follows:

https://github.com/react-bootstrap/react-bootstrap/blob/d28b4f04acbb6910aac4417480f47f5503275791/src/Collapse.js#L7

```javascript
import Transition, {
  EXITED,
  ENTERED,
  ENTERING,
  EXITING,
} from 'react-transition-group/Transition';
```

However, their [build](https://unpkg.com/browse/react-bootstrap@1.0.0-beta.12/Collapse.js) ends up using the values defined in the bottom of `src/Transition.js` in this repo:

```javascript
Transition.UNMOUNTED = 0
Transition.EXITED = 1
Transition.ENTERING = 2
Transition.ENTERED = 3
Transition.EXITING = 4
```

Instead of the exported ones:

```javascript
export const UNMOUNTED = 'unmounted'
export const EXITED = 'exited'
export const ENTERING = 'entering'
export const ENTERED = 'entered'
export const EXITING = 'exiting'
```
This PR makes the values match in order to fix the inconsistencies, and should not be a breaking change, since the features would work exactly the same as documented. Maybe the constants `Transition.UNMOUNTED`, `Transition.EXITED`, etc, should be removed altogether though, since I am not sure they serve any purpose