### PR TITLE
feat: add `nodeRef` alternative instead of internal `findDOMNode`

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,12 +1,12 @@
-import { configure, addDecorator } from '@storybook/react'
-import { createElement, StrictMode } from 'react'
+import { configure, addDecorator } from '@storybook/react';
+import React from 'react';
 
 addDecorator(
-  storyFn => createElement(StrictMode, undefined, storyFn()),
+  storyFn => <React.StrictMode>{storyFn()}</React.StrictMode>,
 )
 
 function loadStories() {
-  require('../stories')
+  require('../stories');
 }
 
-configure(loadStories, module)
+configure(loadStories, module);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,12 @@
-import { configure } from '@storybook/react';
+import { configure, addDecorator } from '@storybook/react'
+import { createElement, StrictMode } from 'react'
+
+addDecorator(
+  storyFn => createElement(StrictMode, undefined, storyFn()),
+)
 
 function loadStories() {
-  require('../stories');
+  require('../stories')
 }
 
-configure(loadStories, module);
+configure(loadStories, module)

--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -316,7 +316,8 @@ CSSTransition.propTypes = {
   /**
    * A `<Transition>` callback fired immediately after the 'enter' or 'appear' class is
    * applied.
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
    *
    * @type Function(node: HtmlElement, isAppearing: bool)
    */
@@ -325,7 +326,8 @@ CSSTransition.propTypes = {
   /**
    * A `<Transition>` callback fired immediately after the 'enter-active' or
    * 'appear-active' class is applied.
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
    *
    * @type Function(node: HtmlElement, isAppearing: bool)
    */
@@ -334,7 +336,8 @@ CSSTransition.propTypes = {
   /**
    * A `<Transition>` callback fired immediately after the 'enter' or
    * 'appear' classes are **removed** and the `done` class is added to the DOM node.
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
    *
    * @type Function(node: HtmlElement, isAppearing: bool)
    */
@@ -343,7 +346,8 @@ CSSTransition.propTypes = {
   /**
    * A `<Transition>` callback fired immediately after the 'exit' class is
    * applied.
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed
    *
    * @type Function(node: HtmlElement)
    */
@@ -351,7 +355,8 @@ CSSTransition.propTypes = {
 
   /**
    * A `<Transition>` callback fired immediately after the 'exit-active' is applied.
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed
    *
    * @type Function(node: HtmlElement)
    */
@@ -360,7 +365,8 @@ CSSTransition.propTypes = {
   /**
    * A `<Transition>` callback fired immediately after the 'exit' classes
    * are **removed** and the `exit-done` class is added to the DOM node.
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed
    *
    * @type Function(node: HtmlElement)
    */

--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -90,60 +90,71 @@ class CSSTransition extends React.Component {
     exit: {},
   }
 
-  onEnter = (node, appearing) => {
+  onEnter = (maybeNode, maybeAppearing) => {
+    const [node, appearing] = this.resolveArguments(maybeNode, maybeAppearing)
     this.removeClasses(node, 'exit');
     this.addClass(node, appearing ? 'appear' : 'enter', 'base');
 
     if (this.props.onEnter) {
-      this.props.onEnter(node, appearing)
+      this.props.onEnter(maybeNode, maybeAppearing)
     }
   }
 
-  onEntering = (node, appearing) => {
+  onEntering = (maybeNode, maybeAppearing) => {
+    const [node, appearing] = this.resolveArguments(maybeNode, maybeAppearing)
     const type = appearing ? 'appear' : 'enter';
     this.addClass(node, type, 'active')
 
     if (this.props.onEntering) {
-      this.props.onEntering(node, appearing)
+      this.props.onEntering(maybeNode, maybeAppearing)
     }
   }
 
-  onEntered = (node, appearing) => {
+  onEntered = (maybeNode, maybeAppearing) => {
+    const [node, appearing] = this.resolveArguments(maybeNode, maybeAppearing)
     const type = appearing ? 'appear' : 'enter'
     this.removeClasses(node, type);
     this.addClass(node, type, 'done');
 
     if (this.props.onEntered) {
-      this.props.onEntered(node, appearing)
+      this.props.onEntered(maybeNode, maybeAppearing)
     }
   }
 
-  onExit = (node) => {
+  onExit = (maybeNode) => {
+    const [node] = this.resolveArguments(maybeNode)
     this.removeClasses(node, 'appear');
     this.removeClasses(node, 'enter');
     this.addClass(node, 'exit', 'base')
 
     if (this.props.onExit) {
-      this.props.onExit(node)
+      this.props.onExit(maybeNode)
     }
   }
 
-  onExiting = (node) => {
+  onExiting = (maybeNode) => {
+    const [node] = this.resolveArguments(maybeNode)
     this.addClass(node, 'exit', 'active')
 
     if (this.props.onExiting) {
-      this.props.onExiting(node)
+      this.props.onExiting(maybeNode)
     }
   }
 
-  onExited = (node) => {
+  onExited = (maybeNode) => {
+    const [node] = this.resolveArguments(maybeNode)
     this.removeClasses(node, 'exit');
     this.addClass(node, 'exit', 'done');
 
     if (this.props.onExited) {
-      this.props.onExited(node)
+      this.props.onExited(maybeNode)
     }
   }
+
+  // when prop `nodeRef` is provided `node` is excluded
+  resolveArguments = (maybeNode, maybeAppearing) => this.props.nodeRef
+    ? [this.props.nodeRef.current, maybeNode] // here `maybeNode` is actually `appearing`
+    : [maybeNode, maybeAppearing] // `findDOMNode` was used
 
   getClassNames = (type) => {
     const { classNames } = this.props;
@@ -305,6 +316,7 @@ CSSTransition.propTypes = {
   /**
    * A `<Transition>` callback fired immediately after the 'enter' or 'appear' class is
    * applied.
+   * Note: when `nodeRef` prop is passed, `node` is not passed
    *
    * @type Function(node: HtmlElement, isAppearing: bool)
    */
@@ -313,6 +325,7 @@ CSSTransition.propTypes = {
   /**
    * A `<Transition>` callback fired immediately after the 'enter-active' or
    * 'appear-active' class is applied.
+   * Note: when `nodeRef` prop is passed, `node` is not passed
    *
    * @type Function(node: HtmlElement, isAppearing: bool)
    */
@@ -321,6 +334,7 @@ CSSTransition.propTypes = {
   /**
    * A `<Transition>` callback fired immediately after the 'enter' or
    * 'appear' classes are **removed** and the `done` class is added to the DOM node.
+   * Note: when `nodeRef` prop is passed, `node` is not passed
    *
    * @type Function(node: HtmlElement, isAppearing: bool)
    */
@@ -329,6 +343,7 @@ CSSTransition.propTypes = {
   /**
    * A `<Transition>` callback fired immediately after the 'exit' class is
    * applied.
+   * Note: when `nodeRef` prop is passed, `node` is not passed
    *
    * @type Function(node: HtmlElement)
    */
@@ -336,6 +351,7 @@ CSSTransition.propTypes = {
 
   /**
    * A `<Transition>` callback fired immediately after the 'exit-active' is applied.
+   * Note: when `nodeRef` prop is passed, `node` is not passed
    *
    * @type Function(node: HtmlElement)
    */
@@ -344,6 +360,7 @@ CSSTransition.propTypes = {
   /**
    * A `<Transition>` callback fired immediately after the 'exit' classes
    * are **removed** and the `exit-done` class is added to the DOM node.
+   * Note: when `nodeRef` prop is passed, `node` is not passed
    *
    * @type Function(node: HtmlElement)
    */

--- a/src/ReplaceTransition.js
+++ b/src/ReplaceTransition.js
@@ -28,7 +28,13 @@ class ReplaceTransition extends React.Component {
     const child = React.Children.toArray(children)[idx];
 
     if (child.props[handler]) child.props[handler](...originalArgs)
-    if (this.props[handler]) this.props[handler](ReactDOM.findDOMNode(this))
+    if (this.props[handler]) {
+      const nodeRef = idx === 0
+        ? this.props.firstNodeRef
+        : this.props.secondNodeRef
+
+      this.props[handler](nodeRef ? undefined : ReactDOM.findDOMNode(this))
+    }
   }
 
   render() {
@@ -45,6 +51,8 @@ class ReplaceTransition extends React.Component {
     delete props.onExit;
     delete props.onExiting;
     delete props.onExited;
+    delete props.firstNodeRef;
+    delete props.secondNodeRef;
 
     return (
       <TransitionGroup {...props}>
@@ -76,6 +84,13 @@ ReplaceTransition.propTypes = {
 
     return null;
   },
+
+  /**
+   * A react reference to DOM element that need to transition
+   * https://stackoverflow.com/a/51127130/4671932
+   */
+  firstNodeRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  secondNodeRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) })
 };
 
 export default ReplaceTransition;

--- a/src/ReplaceTransition.js
+++ b/src/ReplaceTransition.js
@@ -29,11 +29,11 @@ class ReplaceTransition extends React.Component {
 
     if (child.props[handler]) child.props[handler](...originalArgs)
     if (this.props[handler]) {
-      const nodeRef = idx === 0
-        ? this.props.firstNodeRef
-        : this.props.secondNodeRef
+      const maybeNode = child.props.nodeRef
+        ? undefined
+        : ReactDOM.findDOMNode(this)
 
-      this.props[handler](nodeRef ? undefined : ReactDOM.findDOMNode(this))
+      this.props[handler](maybeNode)
     }
   }
 
@@ -51,8 +51,6 @@ class ReplaceTransition extends React.Component {
     delete props.onExit;
     delete props.onExiting;
     delete props.onExited;
-    delete props.firstNodeRef;
-    delete props.secondNodeRef;
 
     return (
       <TransitionGroup {...props}>
@@ -84,13 +82,6 @@ ReplaceTransition.propTypes = {
 
     return null;
   },
-
-  /**
-   * A react reference to DOM element that need to transition
-   * https://stackoverflow.com/a/51127130/4671932
-   */
-  firstNodeRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
-  secondNodeRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) })
 };
 
 export default ReplaceTransition;

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -384,14 +384,15 @@ class Transition extends React.Component {
 
 Transition.propTypes = {
   /**
-   * A react reference to DOM element that need to transition
+   * A React reference to DOM element that need to transition:
    * https://stackoverflow.com/a/51127130/4671932
-   * Note: When `nodeRef` prop is used, `node` is not passed to callback functions (e.g. `onEnter`)
-   * because user already has direct access to the node
-   * Note: When changing `key` prop of `Transition` in a `TransitionGroup`
-   * a new `nodeRef` need to be provided to `Transition` with changed `key` prop
-   * (see [test/CSSTransition-test.js](https://github.com/reactjs/react-transition-group/blob/master/test/CSSTransition-test.js))
-   * CSSTransition > reentering > should remove dynamically applied classes
+   *
+   *   - When `nodeRef` prop is used, `node` is not passed to callback functions
+   *      (e.g. `onEnter`) because user already has direct access to the node.
+   *   - When changing `key` prop of `Transition` in a `TransitionGroup` a new
+   *     `nodeRef` need to be provided to `Transition` with changed `key` prop
+   *     (see
+   *     [test/CSSTransition-test.js](https://github.com/reactjs/react-transition-group/blob/13435f897b3ab71f6e19d724f145596f5910581c/test/CSSTransition-test.js#L362-L437)).
    */
   nodeRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
 
@@ -491,8 +492,9 @@ Transition.propTypes = {
   /**
    * Add a custom transition end trigger. Called with the transitioning
    * DOM node and a `done` callback. Allows for more fine grained transition end
-   * logic. **Note:** Timeouts are still used as a fallback if provided.
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   * logic. Timeouts are still used as a fallback if provided.
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
    *
    * ```jsx
    * addEndListener={(node, done) => {
@@ -506,7 +508,8 @@ Transition.propTypes = {
   /**
    * Callback fired before the "entering" status is applied. An extra parameter
    * `isAppearing` is supplied to indicate if the enter stage is occurring on the initial mount
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
    *
    * @type Function(node: HtmlElement, isAppearing: bool) -> void
    */
@@ -515,7 +518,8 @@ Transition.propTypes = {
   /**
    * Callback fired after the "entering" status is applied. An extra parameter
    * `isAppearing` is supplied to indicate if the enter stage is occurring on the initial mount
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
    *
    * @type Function(node: HtmlElement, isAppearing: bool)
    */
@@ -524,7 +528,8 @@ Transition.propTypes = {
   /**
    * Callback fired after the "entered" status is applied. An extra parameter
    * `isAppearing` is supplied to indicate if the enter stage is occurring on the initial mount
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
    *
    * @type Function(node: HtmlElement, isAppearing: bool) -> void
    */
@@ -532,7 +537,8 @@ Transition.propTypes = {
 
   /**
    * Callback fired before the "exiting" status is applied.
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
    *
    * @type Function(node: HtmlElement) -> void
    */
@@ -540,7 +546,8 @@ Transition.propTypes = {
 
   /**
    * Callback fired after the "exiting" status is applied.
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
    *
    * @type Function(node: HtmlElement) -> void
    */
@@ -548,7 +555,8 @@ Transition.propTypes = {
 
   /**
    * Callback fired after the "exited" status is applied.
-   * Note: when `nodeRef` prop is passed, `node` is not passed
+   *
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed
    *
    * @type Function(node: HtmlElement) -> void
    */

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -545,6 +545,10 @@ Transition.propTypes = {
   /**
    * A react reference to DOM element that need to transition
    * https://stackoverflow.com/a/51127130/4671932
+   * Be aware when changing `key` prop of `Transition` in a `TransitionGroup`
+   * a new `nodeRef` need to be provided to `Transition` with changed `key` prop
+   * e.g. test/CSSTransition-test.js
+   * CSSTransition > reentering > should remove dynamically applied classes
    */
   nodeRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) })
 }

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -169,7 +169,7 @@ class Transition extends React.Component {
     this.updateStatus(true, this.appearStatus)
   }
 
-  componentDidUpdate(prevProps, _prevState, _snapshot) {
+  componentDidUpdate(prevProps) {
     let nextStatus = null
     if (prevProps !== this.props) {
       const { status } = this.state
@@ -384,6 +384,18 @@ class Transition extends React.Component {
 
 Transition.propTypes = {
   /**
+   * A react reference to DOM element that need to transition
+   * https://stackoverflow.com/a/51127130/4671932
+   * Note: When `nodeRef` prop is used, `node` is not passed to callback functions (e.g. `onEnter`)
+   * because user already has direct access to the node
+   * Note: When changing `key` prop of `Transition` in a `TransitionGroup`
+   * a new `nodeRef` need to be provided to `Transition` with changed `key` prop
+   * (see [test/CSSTransition-test.js](https://github.com/reactjs/react-transition-group/blob/master/test/CSSTransition-test.js))
+   * CSSTransition > reentering > should remove dynamically applied classes
+   */
+  nodeRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+
+  /**
    * A `function` child can be used instead of a React element. This function is
    * called with the current transition status (`'entering'`, `'entered'`,
    * `'exiting'`, `'exited'`), which can be used to apply context
@@ -541,16 +553,6 @@ Transition.propTypes = {
    * @type Function(node: HtmlElement) -> void
    */
   onExited: PropTypes.func,
-
-  /**
-   * A react reference to DOM element that need to transition
-   * https://stackoverflow.com/a/51127130/4671932
-   * Be aware when changing `key` prop of `Transition` in a `TransitionGroup`
-   * a new `nodeRef` need to be provided to `Transition` with changed `key` prop
-   * e.g. test/CSSTransition-test.js
-   * CSSTransition > reentering > should remove dynamically applied classes
-   */
-  nodeRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) })
 }
 
 // Name the function so it is clearer in the documentation

--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -66,6 +66,7 @@ class TransitionGroup extends React.Component {
     }
   }
 
+  // node is `undefined` when user provided `nodeRef` prop
   handleExited(child, node) {
     let currentChildMapping = getChildMapping(this.props.children)
 

--- a/stories/CSSTransitionGroupFixture.js
+++ b/stories/CSSTransitionGroupFixture.js
@@ -1,18 +1,16 @@
-import React from 'react';
+import React, { useRef } from 'react'
 
 import TransitionGroup from '../src/TransitionGroup';
 import StoryFixture from './StoryFixture';
 
 class CSSTransitionGroupFixture extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+  static defaultProps = {
+    items: []
+  }
 
-    let items = props.items || [];
-
-    this.count = items.length;
-    this.state = {
-      items,
-    };
+  count = this.props.items.length
+  state = {
+    items: this.props.items
   }
 
   handleAddItem = () => {
@@ -39,7 +37,8 @@ class CSSTransitionGroupFixture extends React.Component {
   }
 
   render() {
-    const { items: _, description, children, ...props } = this.props;
+    const { items: _, description, children, ...rest } = this.props;
+    const { type: Transition, props: transitionProps } = React.Children.only(children)
 
     return (
       <StoryFixture description={description}>
@@ -52,18 +51,13 @@ class CSSTransitionGroupFixture extends React.Component {
             Remove a few
           </button>
         </div>
-        <TransitionGroup component="div" {...props}>
-          {this.state.items.map(item => React.cloneElement(children, {
-            key: item,
-            children: (
-              <div>
-                {item}
-                <button onClick={() => this.handleRemoveItem(item)}>
-                  &times;
-                </button>
-              </div>
-            )
-          }))}
+        <TransitionGroup component="div" {...rest}>
+          {this.state.items.map(item => (
+            <Transition {...transitionProps} key={item}>
+              {item}
+              <button onClick={() => this.handleRemoveItem(item)}>&times;</button>
+            </Transition>
+          ))}
         </TransitionGroup>
       </StoryFixture>
     );

--- a/stories/CSSTransitionGroupFixture.js
+++ b/stories/CSSTransitionGroupFixture.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React from 'react'
 
 import TransitionGroup from '../src/TransitionGroup';
 import StoryFixture from './StoryFixture';
@@ -38,7 +38,8 @@ class CSSTransitionGroupFixture extends React.Component {
 
   render() {
     const { items: _, description, children, ...rest } = this.props;
-    const { type: Transition, props: transitionProps } = React.Children.only(children)
+    // e.g. `Fade`, see where `CSSTransitionGroupFixture` is used
+    const { type: TransitionType, props: transitionTypeProps } = React.Children.only(children)
 
     return (
       <StoryFixture description={description}>
@@ -53,10 +54,10 @@ class CSSTransitionGroupFixture extends React.Component {
         </div>
         <TransitionGroup component="div" {...rest}>
           {this.state.items.map(item => (
-            <Transition {...transitionProps} key={item}>
+            <TransitionType {...transitionTypeProps} key={item}>
               {item}
               <button onClick={() => this.handleRemoveItem(item)}>&times;</button>
-            </Transition>
+            </TransitionType>
           ))}
         </TransitionGroup>
       </StoryFixture>

--- a/stories/NestedTransition.js
+++ b/stories/NestedTransition.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react'
 
 import StoryFixture from './StoryFixture';
 import Fade from './transitions/Fade';
@@ -7,9 +7,8 @@ import Scale from './transitions/Scale';
 function FadeAndScale(props) {
   return (
     <Fade {...props}>
-      <div>
-        <div>I will fade</div>
-        {/*
+      <div>I will fade</div>
+      {/*
           We also want to scale in at the same time so we pass the `in` state here as well, so it enters
           at the same time as the Fade.
 
@@ -17,10 +16,9 @@ function FadeAndScale(props) {
           will mount at the same time as the div we want to scale, so we need to tell it to animate as
           it _appears_.
         */}
-        <Scale in={props.in} appear>
-          <div>I should scale</div>
-        </Scale>
-      </div>
+      <Scale in={props.in} appear>
+        I should scale
+      </Scale>
     </Fade>
   );
 }

--- a/stories/ReplaceTransition.js
+++ b/stories/ReplaceTransition.js
@@ -40,7 +40,6 @@ const styles = css`
 
 const defaultProps = {
   in: false,
-  delay: false,
   timeout: FADE_TIMEOUT * 2,
 }
 
@@ -55,8 +54,6 @@ function Fade(props) {
 }
 
 Fade.defaultProps = defaultProps;
-
-export default Fade;
 
 function Example({ children }) {
   const [show, setShow] = useState(false);
@@ -77,20 +74,29 @@ function Example({ children }) {
 
 
 storiesOf('Replace Transition', module)
-  .add('Animates on all', () => (
-
-    <Example>
-      <ReplaceTransition
-        className={styles.container}
-        onEnter={() => console.log('onEnter')}
-        onEntering={() => console.log('onEntering')}
-        onEntered={() => console.log('onEntered')}
-        onExit={() => console.log('onExit')}
-        onExiting={() => console.log('onExiting')}
-        onExited={() => console.log('onExited')}
-      >
-        <Fade><div>in True</div></Fade>
-        <Fade><div>in False</div></Fade>
-      </ReplaceTransition>
-    </Example>
-  ))
+  .add('Animates on all', () => {
+    const firstNodeRef = React.createRef()
+    const secondNodeRef = React.createRef()
+    return (
+      <Example>
+        <ReplaceTransition
+          in={false} // `Example` is overriding this prop
+          firstNodeRef={firstNodeRef}
+          secondNodeRef={secondNodeRef}
+          className={styles.container}
+          onEnter={() => console.log('onEnter')}
+          onEntering={() => console.log('onEntering')}
+          onEntered={() => console.log('onEntered')}
+          onExit={() => console.log('onExit')}
+          onExiting={() => console.log('onExiting')}
+          onExited={() => console.log('onExited')}>
+          <Fade nodeRef={firstNodeRef}>
+            <div ref={firstNodeRef}>in True</div>
+          </Fade>
+          <Fade nodeRef={secondNodeRef}>
+            <div ref={secondNodeRef}>in False</div>
+          </Fade>
+        </ReplaceTransition>
+      </Example>
+    )
+  })

--- a/stories/ReplaceTransition.js
+++ b/stories/ReplaceTransition.js
@@ -81,8 +81,6 @@ storiesOf('Replace Transition', module)
       <Example>
         <ReplaceTransition
           in={false} // `Example` is overriding this prop
-          firstNodeRef={firstNodeRef}
-          secondNodeRef={secondNodeRef}
           className={styles.container}
           onEnter={() => console.log('onEnter')}
           onEntering={() => console.log('onEntering')}

--- a/stories/Transition.js
+++ b/stories/Transition.js
@@ -26,19 +26,15 @@ function ToggleFixture({ defaultIn, description, children }) {
 storiesOf('Transition', module)
   .add('Bootstrap Fade', () => (
     <ToggleFixture>
-      <Fade>
-        <div>asaghasg asgasg</div>
-      </Fade>
+      <Fade>asaghasg asgasg</Fade>
     </ToggleFixture>
   ))
   .add('Bootstrap Collapse', () => (
     <ToggleFixture>
       <Collapse>
-        <div>
-          asaghasg asgasg
-          <div>foo</div>
-          <div>bar</div>
-        </div>
+        asaghasg asgasg
+        <div>foo</div>
+        <div>bar</div>
       </Collapse>
     </ToggleFixture>
   ))

--- a/stories/Transition.js
+++ b/stories/Transition.js
@@ -2,17 +2,17 @@ import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
 
 import StoryFixture from './StoryFixture'
-import { Fade, Collapse } from './transitions/Bootstrap'
+import { Fade, Collapse, FadeForwardRef, FadeInnerRef } from './transitions/Bootstrap'
 
 function ToggleFixture({ defaultIn, description, children }) {
-  const [show, setShow] = useState(defaultIn);
+  const [show, setShow] = useState(defaultIn)
 
   return (
     <StoryFixture description={description}>
       <div style={{ marginBottom: 10 }}>
         <button
           onClick={() => {
-            setShow(!show);
+            setShow(!show)
           }}
         >
           Toggle
@@ -20,7 +20,7 @@ function ToggleFixture({ defaultIn, description, children }) {
       </div>
       {React.cloneElement(children, { in: show })}
     </StoryFixture>
-  );
+  )
 }
 
 storiesOf('Transition', module)
@@ -38,3 +38,20 @@ storiesOf('Transition', module)
       </Collapse>
     </ToggleFixture>
   ))
+  .add('Fade using React.forwardRef', () => {
+    const nodeRef = React.createRef()
+    return (
+      <ToggleFixture>
+        <FadeForwardRef ref={nodeRef}>Fade using React.forwardRef</FadeForwardRef>
+      </ToggleFixture>
+    )
+  })
+  .add('Fade using innerRef', () => {
+    const nodeRef = React.createRef()
+    return (
+      <ToggleFixture>
+        <FadeInnerRef innerRef={nodeRef}>Fade using innerRef</FadeInnerRef>
+      </ToggleFixture>
+    )
+  })
+

--- a/stories/TransitionGroup.js
+++ b/stories/TransitionGroup.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react'
 import { storiesOf } from '@storybook/react';
 
 import TransitionGroup from '../src/TransitionGroup';
@@ -88,6 +88,7 @@ storiesOf('Css Transition Group', module)
   ;
 
 class DynamicTransition extends React.Component {
+  nodeRef = React.createRef()
   state = { count: 0 }
   handleClick = () => {
     this.setState({ hide: !this.state.hide })
@@ -107,8 +108,8 @@ class DynamicTransition extends React.Component {
         <button onClick={this.handleClick}>Toggle item</button>
         <TransitionGroup timeout={FADE_TIMEOUT}>
           {!hide &&
-            <Fade key='item'>
-              <div>Changing! {count}</div>
+            <Fade nodeRef={this.nodeRef} key='item'>
+              <div ref={this.nodeRef}>Changing! {count}</div>
             </Fade>
           }
         </TransitionGroup>
@@ -119,6 +120,7 @@ class DynamicTransition extends React.Component {
 
 function ReEnterTransition() {
   const [hide, setHide] = useState(false);
+  const nodeRef = useRef()
 
   useEffect(() => {
     if (hide) {
@@ -140,8 +142,8 @@ function ReEnterTransition() {
       </button>
       <TransitionGroup timeout={FADE_TIMEOUT}>
         {!hide && (
-          <Fade key='item'>
-            <div>I'm entering!</div>
+          <Fade nodeRef={nodeRef} key='item'>
+            <div ref={nodeRef}>I'm entering!</div>
           </Fade>
         )}
       </TransitionGroup>

--- a/stories/TransitionGroup.js
+++ b/stories/TransitionGroup.js
@@ -88,7 +88,6 @@ storiesOf('Css Transition Group', module)
   ;
 
 class DynamicTransition extends React.Component {
-  nodeRef = React.createRef()
   state = { count: 0 }
   handleClick = () => {
     this.setState({ hide: !this.state.hide })
@@ -107,11 +106,7 @@ class DynamicTransition extends React.Component {
       <div>
         <button onClick={this.handleClick}>Toggle item</button>
         <TransitionGroup timeout={FADE_TIMEOUT}>
-          {!hide &&
-            <Fade nodeRef={this.nodeRef} key='item'>
-              <div ref={this.nodeRef}>Changing! {count}</div>
-            </Fade>
-          }
+          {!hide && <Fade key='item'>Changing! {count}</Fade>}
         </TransitionGroup>
       </div>
     )
@@ -120,7 +115,6 @@ class DynamicTransition extends React.Component {
 
 function ReEnterTransition() {
   const [hide, setHide] = useState(false);
-  const nodeRef = useRef()
 
   useEffect(() => {
     if (hide) {
@@ -142,9 +136,7 @@ function ReEnterTransition() {
       </button>
       <TransitionGroup timeout={FADE_TIMEOUT}>
         {!hide && (
-          <Fade nodeRef={nodeRef} key='item'>
-            <div ref={nodeRef}>I'm entering!</div>
-          </Fade>
+          <Fade key='item'>I'm entering!</Fade>
         )}
       </TransitionGroup>
     </div>

--- a/stories/transitions/Bootstrap.js
+++ b/stories/transitions/Bootstrap.js
@@ -1,5 +1,5 @@
 import { css } from 'astroturf';
-import React, { useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import style from 'dom-helpers/css';
 
 import Transition, { EXITED, ENTERED, ENTERING, EXITING }
@@ -117,4 +117,48 @@ export class Collapse extends React.Component {
       </Transition>
     );
   }
+}
+
+export function FadeInnerRef(props) {
+  const nodeRef = useMergedRef(props.innerRef)
+  return (
+    <Transition
+      {...props}
+      nodeRef={nodeRef}
+      className={styles.fade}
+      timeout={150}>
+      {status => (
+        <div ref={nodeRef} className={`${styles.fade} ${fadeStyles[status] || ''}`}>
+          {props.children}
+        </div>
+      )}
+    </Transition>
+  )
+}
+
+export const FadeForwardRef = React.forwardRef((props, ref) => {
+  return <FadeInnerRef {...props} innerRef={ref} />
+})
+
+/**
+ * Compose multiple refs, there may be different implementations
+ * This one is derived from
+ * e.g. https://github.com/react-restart/hooks/blob/ed37bf3dfc8fc1d9234a6d8fe0af94d69fad3b74/src/useMergedRefs.ts
+ * Also here are good discussion about this
+ * https://github.com/facebook/react/issues/13029
+ * @param ref
+ * @returns {React.MutableRefObject<undefined>}
+ */
+function useMergedRef(ref) {
+  const nodeRef = React.useRef()
+  useEffect(function () {
+    if (ref) {
+      if (typeof ref === 'function') {
+        ref(nodeRef.current)
+      } else {
+        ref.current = nodeRef.current
+      }
+    }
+  })
+  return nodeRef
 }

--- a/stories/transitions/Fade.js
+++ b/stories/transitions/Fade.js
@@ -1,5 +1,5 @@
 import { css } from 'astroturf';
-import React from 'react';
+import React, { useRef } from 'react'
 
 import CSSTransition from '../../src/CSSTransition';
 
@@ -32,7 +32,12 @@ const defaultProps = {
 };
 
 function Fade(props) {
-  return <CSSTransition {...props} classNames={styles} />;
+  const nodeRef = useRef()
+  return (
+    <CSSTransition {...props} classNames={styles} nodeRef={nodeRef}>
+      <div ref={nodeRef}>{props.children}</div>
+    </CSSTransition>
+  );
 }
 
 Fade.defaultProps = defaultProps;

--- a/stories/transitions/Scale.js
+++ b/stories/transitions/Scale.js
@@ -1,5 +1,5 @@
 import { css } from 'astroturf';
-import React from 'react';
+import React, { useRef } from 'react'
 
 import CSSTransition from '../../src/CSSTransition';
 
@@ -32,7 +32,12 @@ const defaultProps = {
 };
 
 function Scale(props) {
-  return <CSSTransition {...props} classNames={styles} />;
+  const nodeRef = useRef()
+  return (
+    <CSSTransition {...props} classNames={styles} nodeRef={nodeRef}>
+      <div ref={nodeRef}>{props.children}</div>
+    </CSSTransition>
+  );
 }
 
 Scale.defaultProps = defaultProps;

--- a/test/CSSTransition-test.js
+++ b/test/CSSTransition-test.js
@@ -177,23 +177,25 @@ describe('CSSTransition', () => {
     });
 
     it('should not add undefined when appearDone is not defined', done => {
+      const nodeRef = React.createRef()
       mount(
         <CSSTransition
           timeout={10}
+          nodeRef={nodeRef}
           classNames={{ appear: 'appear-test' }}
           in={true}
           appear={true}
-          onEnter={(node, isAppearing) => {
+          onEnter={(isAppearing) => {
             expect(isAppearing).toEqual(true);
-            expect(node.className).toEqual('appear-test');
+            expect(nodeRef.current.className).toEqual('appear-test');
           }}
-          onEntered={(node, isAppearing) => {
+          onEntered={(isAppearing) => {
             expect(isAppearing).toEqual(true);
-            expect(node.className).toEqual('');
+            expect(nodeRef.current.className).toEqual('');
             done();
           }}
         >
-          <div/>
+          <div ref={nodeRef}/>
         </CSSTransition>
       );
     });
@@ -406,8 +408,12 @@ describe('CSSTransition', () => {
         }
       }
 
-      let nodeRef = React.createRef()
-      const wrapper = mount(<Test direction="down" text="foo" nodeRef={nodeRef} />)
+      const nodeRef = {
+        foo: React.createRef(),
+        bar: React.createRef(),
+      }
+
+      const wrapper = mount(<Test direction="down" text="foo" nodeRef={nodeRef.foo} />)
 
       const rerender = getProps => new Promise(resolve =>
         wrapper.setProps({
@@ -421,38 +427,34 @@ describe('CSSTransition', () => {
         })
       );
 
-      nodeRef = React.createRef()
-
       await rerender(resolve => ({
         direction: 'up',
         text: 'bar',
-        nodeRef,
+        nodeRef: nodeRef.bar,
 
         onEnter() {
           count++;
-          expect(nodeRef.current.className).toEqual('up-enter');
+          expect(nodeRef.bar.current.className).toEqual('up-enter');
         },
         onEntering() {
           count++;
-          expect(nodeRef.current.className).toEqual('up-enter up-enter-active');
+          expect(nodeRef.bar.current.className).toEqual('up-enter up-enter-active');
           resolve()
         }
       }))
 
-      nodeRef = React.createRef()
-
       await rerender(resolve => ({
         direction: 'down',
         text: 'foo',
-        nodeRef,
+        nodeRef: nodeRef.foo,
 
         onEntering() {
           count++;
-          expect(nodeRef.current.className).toEqual('down-enter down-enter-active');
+          expect(nodeRef.foo.current.className).toEqual('down-enter down-enter-active');
         },
         onEntered() {
           count++;
-          expect(nodeRef.current.className).toEqual('down-enter-done');
+          expect(nodeRef.foo.current.className).toEqual('down-enter-done');
           resolve();
         }
       }))

--- a/test/CSSTransition-test.js
+++ b/test/CSSTransition-test.js
@@ -7,40 +7,43 @@ import TransitionGroup from '../src/TransitionGroup';
 describe('CSSTransition', () => {
 
   it('should flush new props to the DOM before initiating a transition', (done) => {
-    mount(
+    const nodeRef = React.createRef()
+    const wrapper = mount(
       <CSSTransition
         in={false}
+        nodeRef={nodeRef}
         timeout={0}
         classNames="test"
-        onEnter={node => {
-          expect(node.classList.contains('test-class')).toEqual(true)
-          expect(node.classList.contains('test-entering')).toEqual(false)
+        onEnter={() => {
+          expect(nodeRef.current.classList.contains('test-class')).toEqual(true)
+          expect(nodeRef.current.classList.contains('test-entering')).toEqual(false)
           done()
         }}
       >
-        <div></div>
+        <div ref={nodeRef} />
       </CSSTransition>
     )
-    .tap(inst => {
 
-      expect(inst.getDOMNode().classList.contains('test-class')).toEqual(false)
-    })
-    .setProps({
+    expect(nodeRef.current.classList.contains('test-class')).toEqual(false)
+
+    wrapper.setProps({
       in: true,
       className: 'test-class'
     })
   });
 
   describe('entering', () => {
-    let instance;
+    let wrapper, nodeRef;
 
     beforeEach(() => {
-      instance = mount(
+      nodeRef = React.createRef()
+      wrapper = mount(
         <CSSTransition
+          nodeRef={nodeRef}
           timeout={10}
           classNames="test"
         >
-          <div/>
+          <div ref={nodeRef} />
         </CSSTransition>
       )
     });
@@ -48,21 +51,21 @@ describe('CSSTransition', () => {
     it('should apply classes at each transition state', done => {
       let count = 0;
 
-      instance.setProps({
+      wrapper.setProps({
         in: true,
 
-        onEnter(node) {
+        onEnter() {
           count++;
-          expect(node.className).toEqual('test-enter');
+          expect(nodeRef.current.className).toEqual('test-enter');
         },
 
-        onEntering(node){
+        onEntering() {
           count++;
-          expect(node.className).toEqual('test-enter test-enter-active');
+          expect(nodeRef.current.className).toEqual('test-enter test-enter-active');
         },
 
-        onEntered(node){
-          expect(node.className).toEqual('test-enter-done');
+        onEntered() {
+          expect(nodeRef.current.className).toEqual('test-enter-done');
           expect(count).toEqual(2);
           done();
         }
@@ -71,34 +74,36 @@ describe('CSSTransition', () => {
 
     it('should apply custom classNames names', done => {
       let count = 0;
-      instance = mount(
+      const nodeRef = React.createRef()
+      wrapper = mount(
         <CSSTransition
           timeout={10}
+          nodeRef={nodeRef}
           classNames={{
             enter: 'custom',
             enterActive: 'custom-super-active',
             enterDone: 'custom-super-done',
           }}
         >
-          <div/>
+          <div ref={nodeRef} />
         </CSSTransition>
       );
 
-      instance.setProps({
+      wrapper.setProps({
         in: true,
 
-        onEnter(node){
+        onEnter(){
           count++;
-          expect(node.className).toEqual('custom');
+          expect(nodeRef.current.className).toEqual('custom');
         },
 
-        onEntering(node){
+        onEntering(){
           count++;
-          expect(node.className).toEqual('custom custom-super-active');
+          expect(nodeRef.current.className).toEqual('custom custom-super-active');
         },
 
-        onEntered(node){
-          expect(node.className).toEqual('custom-super-done');
+        onEntered(){
+          expect(nodeRef.current.className).toEqual('custom-super-done');
           expect(count).toEqual(2);
           done();
         }
@@ -109,39 +114,43 @@ describe('CSSTransition', () => {
   describe('appearing', () => {
     it('should apply appear classes at each transition state', done => {
       let count = 0;
+      const nodeRef = React.createRef()
       mount(
         <CSSTransition
           timeout={10}
+          nodeRef={nodeRef}
           classNames='appear-test'
           in={true}
           appear={true}
-          onEnter={(node, isAppearing) => {
+          onEnter={(isAppearing) => {
             count++;
             expect(isAppearing).toEqual(true);
-            expect(node.className).toEqual('appear-test-appear');
+            expect(nodeRef.current.className).toEqual('appear-test-appear');
           }}
-          onEntering={(node, isAppearing) => {
+          onEntering={(isAppearing) => {
             count++;
             expect(isAppearing).toEqual(true);
-            expect(node.className).toEqual('appear-test-appear appear-test-appear-active');
+            expect(nodeRef.current.className).toEqual('appear-test-appear appear-test-appear-active');
           }}
 
-          onEntered={(node, isAppearing) => {
+          onEntered={(isAppearing) => {
             expect(isAppearing).toEqual(true);
-            expect(node.className).toEqual('appear-test-appear-done appear-test-enter-done');
+            expect(nodeRef.current.className).toEqual('appear-test-appear-done appear-test-enter-done');
             expect(count).toEqual(2);
             done();
           }}
         >
-          <div/>
+          <div ref={nodeRef} />
         </CSSTransition>
       );
     });
 
     it('should lose the "*-appear-done" class after leaving and entering again', (done) => {
+      const nodeRef = React.createRef()
       const wrapper = mount(
         <CSSTransition
           timeout={10}
+          nodeRef={nodeRef}
           classNames="appear-test"
           in={true}
           appear={true}
@@ -149,12 +158,12 @@ describe('CSSTransition', () => {
             wrapper.setProps({
               in: false,
               onEntered: () => {},
-              onExited: (node) => {
-                expect(node.className).toBe('appear-test-exit-done')
+              onExited: () => {
+                expect(nodeRef.current.className).toBe('appear-test-exit-done')
                 wrapper.setProps({
                   in: true,
                   onEntered: () => {
-                    expect(node.className).toBe('appear-test-enter-done')
+                    expect(nodeRef.current.className).toBe('appear-test-enter-done')
                     done()
                   }
                 })
@@ -162,7 +171,7 @@ describe('CSSTransition', () => {
             })
           }}
         >
-          <div />
+          <div ref={nodeRef} />
         </CSSTransition>
       )
     });
@@ -191,32 +200,34 @@ describe('CSSTransition', () => {
 
     it('should not be appearing in normal enter mode', done => {
       let count = 0;
+      const nodeRef = React.createRef()
       mount(
         <CSSTransition
           timeout={10}
+          nodeRef={nodeRef}
           classNames='not-appear-test'
           appear={true}
         >
-          <div/>
+          <div ref={nodeRef} />
         </CSSTransition>
       ).setProps({
         in: true,
 
-        onEnter(node, isAppearing){
+        onEnter(isAppearing){
           count++;
           expect(isAppearing).toEqual(false);
-          expect(node.className).toEqual('not-appear-test-enter');
+          expect(nodeRef.current.className).toEqual('not-appear-test-enter');
         },
 
-        onEntering(node, isAppearing){
+        onEntering(isAppearing){
           count++;
           expect(isAppearing).toEqual(false);
-          expect(node.className).toEqual('not-appear-test-enter not-appear-test-enter-active');
+          expect(nodeRef.current.className).toEqual('not-appear-test-enter not-appear-test-enter-active');
         },
 
-        onEntered(node, isAppearing){
+        onEntered(isAppearing){
           expect(isAppearing).toEqual(false);
-          expect(node.className).toEqual('not-appear-test-enter-done');
+          expect(nodeRef.current.className).toEqual('not-appear-test-enter-done');
           expect(count).toEqual(2);
           done();
         }
@@ -224,9 +235,11 @@ describe('CSSTransition', () => {
     });
 
     it('should not enter the transition states when appear=false', () => {
+      const nodeRef = React.createRef()
       mount(
         <CSSTransition
           timeout={10}
+          nodeRef={nodeRef}
           classNames='appear-fail-test'
           in={true}
           appear={false}
@@ -240,7 +253,7 @@ describe('CSSTransition', () => {
             throw Error('Entred called!')
           }}
         >
-          <div/>
+          <div ref={nodeRef} />
         </CSSTransition>
       );
     });
@@ -249,16 +262,18 @@ describe('CSSTransition', () => {
   });
 
   describe('exiting', ()=> {
-    let instance;
+    let wrapper, nodeRef;
 
     beforeEach(() => {
-      instance = mount(
+      nodeRef = React.createRef()
+      wrapper = mount(
         <CSSTransition
           in
+          nodeRef={nodeRef}
           timeout={10}
           classNames="test"
         >
-          <div/>
+          <div ref={nodeRef} />
         </CSSTransition>
       )
     });
@@ -266,21 +281,21 @@ describe('CSSTransition', () => {
     it('should apply classes at each transition state', done => {
       let count = 0;
 
-      instance.setProps({
+      wrapper.setProps({
         in: false,
 
-        onExit(node){
+        onExit(){
           count++;
-          expect(node.className).toEqual('test-exit');
+          expect(nodeRef.current.className).toEqual('test-exit');
         },
 
-        onExiting(node){
+        onExiting(){
           count++;
-          expect(node.className).toEqual('test-exit test-exit-active');
+          expect(nodeRef.current.className).toEqual('test-exit test-exit-active');
         },
 
-        onExited(node){
-          expect(node.className).toEqual('test-exit-done');
+        onExited(){
+          expect(nodeRef.current.className).toEqual('test-exit-done');
           expect(count).toEqual(2);
           done();
         }
@@ -289,9 +304,11 @@ describe('CSSTransition', () => {
 
     it('should apply custom classNames names', done => {
       let count = 0;
-      instance = mount(
+      const nodeRef = React.createRef()
+      wrapper = mount(
         <CSSTransition
           in
+          nodeRef={nodeRef}
           timeout={10}
           classNames={{
             exit: 'custom',
@@ -299,25 +316,25 @@ describe('CSSTransition', () => {
             exitDone: 'custom-super-done',
           }}
         >
-          <div/>
+          <div ref={nodeRef} />
         </CSSTransition>
       );
 
-      instance.setProps({
+      wrapper.setProps({
         in: false,
 
-        onExit(node){
+        onExit() {
           count++;
-          expect(node.className).toEqual('custom');
+          expect(nodeRef.current.className).toEqual('custom');
         },
 
-        onExiting(node){
+        onExiting() {
           count++;
-          expect(node.className).toEqual('custom custom-super-active');
+          expect(nodeRef.current.className).toEqual('custom custom-super-active');
         },
 
-        onExited(node){
-          expect(node.className).toEqual('custom-super-done');
+        onExited() {
+          expect(nodeRef.current.className).toEqual('custom-super-done');
           expect(count).toEqual(2);
           done();
         }
@@ -327,30 +344,32 @@ describe('CSSTransition', () => {
     it('should support empty prefix', done => {
       let count = 0;
 
-      const instance = mount(
+      const nodeRef = React.createRef()
+      const wrapper = mount(
         <CSSTransition
           in
+          nodeRef={nodeRef}
           timeout={10}
         >
-          <div/>
+          <div ref={nodeRef} />
         </CSSTransition>
       )
 
-      instance.setProps({
+      wrapper.setProps({
         in: false,
 
-        onExit(node){
+        onExit() {
           count++;
-          expect(node.className).toEqual('exit');
+          expect(nodeRef.current.className).toEqual('exit');
         },
 
-        onExiting(node){
+        onExiting() {
           count++;
-          expect(node.className).toEqual('exit exit-active');
+          expect(nodeRef.current.className).toEqual('exit exit-active');
         },
 
-        onExited(node){
-          expect(node.className).toEqual('exit-done');
+        onExited() {
+          expect(nodeRef.current.className).toEqual('exit-done');
           expect(count).toEqual(2);
           done();
         }
@@ -359,11 +378,11 @@ describe('CSSTransition', () => {
   });
 
   describe('reentering', () => {
-    it('should remove dynamically applied classes', done => {
+    it('should remove dynamically applied classes', async () => {
       let count = 0;
       class Test extends React.Component {
         render() {
-          const { direction, text, ...props } = this.props;
+          const { direction, text, nodeRef, ...props } = this.props;
 
           return (
             <TransitionGroup
@@ -377,19 +396,21 @@ describe('CSSTransition', () => {
               <CSSTransition
                 key={text}
                 timeout={100}
+                nodeRef={nodeRef}
                 {...props}
               >
-                <span>{text}</span>
+                <span ref={nodeRef}>{text}</span>
               </CSSTransition>
             </TransitionGroup>
           )
         }
       }
 
-      const instance = mount(<Test direction="down" text="foo" />)
+      let nodeRef = React.createRef()
+      const wrapper = mount(<Test direction="down" text="foo" nodeRef={nodeRef} />)
 
       const rerender = getProps => new Promise(resolve =>
-        instance.setProps({
+        wrapper.setProps({
           onEnter: undefined,
           onEntering: undefined,
           onEntered: undefined,
@@ -400,40 +421,43 @@ describe('CSSTransition', () => {
         })
       );
 
-      Promise.resolve().then(() =>
-        rerender(resolve => ({
-          direction: 'up',
-          text: 'bar',
+      nodeRef = React.createRef()
 
-          onEnter(node) {
-            count++;
-            expect(node.className).toEqual('up-enter');
-          },
-          onEntering(node) {
-            count++;
-            expect(node.className).toEqual('up-enter up-enter-active');
-            resolve()
-          }
-        }))
-      ).then(() => {
-        return rerender(resolve => ({
-          direction: 'down',
-          text: 'foo',
+      await rerender(resolve => ({
+        direction: 'up',
+        text: 'bar',
+        nodeRef,
 
-          onEntering(node) {
-            count++;
-            expect(node.className).toEqual('down-enter down-enter-active');
-          },
-          onEntered(node) {
-            count++;
-            expect(node.className).toEqual('down-enter-done');
-            resolve();
-          }
-        }))
-      }).then(() => {
-        expect(count).toEqual(4);
-        done();
-      });
+        onEnter() {
+          count++;
+          expect(nodeRef.current.className).toEqual('up-enter');
+        },
+        onEntering() {
+          count++;
+          expect(nodeRef.current.className).toEqual('up-enter up-enter-active');
+          resolve()
+        }
+      }))
+
+      nodeRef = React.createRef()
+
+      await rerender(resolve => ({
+        direction: 'down',
+        text: 'foo',
+        nodeRef,
+
+        onEntering() {
+          count++;
+          expect(nodeRef.current.className).toEqual('down-enter down-enter-active');
+        },
+        onEntered() {
+          count++;
+          expect(nodeRef.current.className).toEqual('down-enter-done');
+          resolve();
+        }
+      }))
+
+      expect(count).toEqual(4);
     });
   });
 });

--- a/test/CSSTransitionGroup-test.js
+++ b/test/CSSTransitionGroup-test.js
@@ -10,7 +10,15 @@ let TransitionGroup;
 describe('CSSTransitionGroup', () => {
   let container;
   let consoleErrorSpy;
-  let YoloTransition;
+
+  function YoloTransition({ id, ...props }) {
+    const nodeRef = React.useRef()
+    return (
+      <CSSTransition nodeRef={nodeRef} classNames="yolo" timeout={0} {...props}>
+        <span ref={nodeRef} id={id} />
+      </CSSTransition>
+    )
+  }
 
   beforeEach(() => {
     jest.resetModuleRegistry();
@@ -20,18 +28,6 @@ describe('CSSTransitionGroup', () => {
     ReactDOM = require('react-dom');
 
     TransitionGroup = require('../src/TransitionGroup');
-
-    YoloTransition = class extends React.Component {
-      nodeRef = React.createRef()
-      render() {
-        let { id, ...props } = this.props
-        return (
-          <CSSTransition nodeRef={this.nodeRef} classNames="yolo" timeout={0} {...props}>
-            <span ref={this.nodeRef} id={id} />
-          </CSSTransition>
-        )
-      }
-    }
 
     container = document.createElement('div');
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/test/CSSTransitionGroup-test.js
+++ b/test/CSSTransitionGroup-test.js
@@ -10,14 +10,7 @@ let TransitionGroup;
 describe('CSSTransitionGroup', () => {
   let container;
   let consoleErrorSpy;
-
-  function YoloTransition({ id, ...props }) {
-    return (
-      <CSSTransition classNames="yolo" timeout={0} {...props}>
-        <span id={id} />
-      </CSSTransition>
-    )
-  }
+  let YoloTransition;
 
   beforeEach(() => {
     jest.resetModuleRegistry();
@@ -27,6 +20,18 @@ describe('CSSTransitionGroup', () => {
     ReactDOM = require('react-dom');
 
     TransitionGroup = require('../src/TransitionGroup');
+
+    YoloTransition = class extends React.Component {
+      nodeRef = React.createRef()
+      render() {
+        let { id, ...props } = this.props
+        return (
+          <CSSTransition nodeRef={this.nodeRef} classNames="yolo" timeout={0} {...props}>
+            <span ref={this.nodeRef} id={id} />
+          </CSSTransition>
+        )
+      }
+    }
 
     container = document.createElement('div');
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/test/SwitchTransition-test.js
+++ b/test/SwitchTransition-test.js
@@ -10,20 +10,21 @@ describe('SwitchTransition', () => {
   beforeEach(() => {
     log = [];
     let events = {
-      onEnter: (_, m) => log.push(m ? 'appear' : 'enter'),
-      onEntering: (_, m) => log.push(m ? 'appearing' : 'entering'),
-      onEntered: (_, m) => log.push(m ? 'appeared' : 'entered'),
+      onEnter: (m) => log.push(m ? 'appear' : 'enter'),
+      onEntering: (m) => log.push(m ? 'appearing' : 'entering'),
+      onEntered: (m) => log.push(m ? 'appeared' : 'entered'),
       onExit: () => log.push('exit'),
       onExiting: () => log.push('exiting'),
       onExited: () => log.push('exited')
     };
 
+    const nodeRef = React.createRef()
     Parent = function Parent({ on, rendered = true }) {
       return (
         <SwitchTransition>
           {rendered ? (
-            <Transition timeout={0} key={on ? 'first' : 'second'} {...events}>
-              <span />
+            <Transition nodeRef={nodeRef} timeout={0} key={on ? 'first' : 'second'} {...events}>
+              <span ref={nodeRef} />
             </Transition>
           ) : null}
         </SwitchTransition>
@@ -32,10 +33,11 @@ describe('SwitchTransition', () => {
   });
 
   it('should have default status ENTERED', () => {
+    const nodeRef = React.createRef()
     const wrapper = mount(
       <SwitchTransition>
-        <Transition timeout={0} key="first">
-          <span />
+        <Transition nodeRef={nodeRef} timeout={0} key="first">
+          <span ref={nodeRef} />
         </Transition>
       </SwitchTransition>
     );
@@ -44,10 +46,11 @@ describe('SwitchTransition', () => {
   });
 
   it('should have default mode: out-in', () => {
+    const nodeRef = React.createRef()
     const wrapper = mount(
       <SwitchTransition>
-        <Transition timeout={0} key="first">
-          <span />
+        <Transition nodeRef={nodeRef} timeout={0} key="first">
+          <span ref={nodeRef} />
         </Transition>
       </SwitchTransition>
     );
@@ -56,11 +59,12 @@ describe('SwitchTransition', () => {
   });
 
   it('should work without childs', () => {
+    const nodeRef = React.createRef()
     expect(() => {
       mount(
         <SwitchTransition>
-          <Transition timeout={0} key="first">
-            <span />
+          <Transition nodeRef={nodeRef} timeout={0} key="first">
+            <span ref={nodeRef} />
           </Transition>
         </SwitchTransition>
       );

--- a/test/Transition-test.js
+++ b/test/Transition-test.js
@@ -25,15 +25,17 @@ expect.extend({
 
 describe('Transition', () => {
   it('should not transition on mount', () => {
+    const nodeRef = React.createRef()
     let wrapper = mount(
       <Transition
         in
+        nodeRef={nodeRef}
         timeout={0}
         onEnter={() => {
           throw new Error('should not Enter')
         }}
       >
-        <div />
+        <div ref={nodeRef} />
       </Transition>
     )
 
@@ -41,21 +43,23 @@ describe('Transition', () => {
   })
 
   it('should transition on mount with `appear`', done => {
+    const nodeRef = React.createRef()
     mount(
       <Transition
         in
+        nodeRef={nodeRef}
         timeout={0}
         onEnter={() => {
           throw Error('Animated!')
         }}
       >
-        <div />
+        <div ref={nodeRef} />
       </Transition>
     )
 
     mount(
-      <Transition in appear timeout={0} onEnter={() => done()}>
-        <div />
+      <Transition nodeRef={nodeRef} in appear timeout={0} onEnter={() => done()}>
+        <div ref={nodeRef} />
       </Transition>
     )
   })
@@ -63,14 +67,16 @@ describe('Transition', () => {
   it('should pass filtered props to children', () => {
     class Child extends React.Component {
       render() {
-        return <div>child</div>
+        return <div ref={this.props.nodeRef}>child</div>
       }
     }
+    const nodeRef = React.createRef()
     const child = mount(
       <Transition
         foo="foo"
         bar="bar"
         in
+        nodeRef={nodeRef}
         mountOnEnter
         unmountOnExit
         appear
@@ -85,59 +91,64 @@ describe('Transition', () => {
         onExiting={() => {}}
         onExited={() => {}}
       >
-        <Child />
+        <Child nodeRef={nodeRef} />
       </Transition>
     ).find(Child)
 
-    expect(child.props()).toEqual({ foo: 'foo', bar: 'bar' })
+    expect(child.props()).toEqual({ foo: 'foo', bar: 'bar', nodeRef })
   })
 
   it('should allow addEndListener instead of timeouts', done => {
-    let listener = jest.fn((node, end) => setTimeout(end, 0))
+    let listener = jest.fn(end => setTimeout(end, 0))
 
-    let inst = mount(
+    const nodeRef = React.createRef()
+    let wrapper = mount(
       <Transition
+        nodeRef={nodeRef}
         addEndListener={listener}
         onEntered={() => {
           expect(listener).toHaveBeenCalledTimes(1)
           done()
         }}
       >
-        <div />
+        <div ref={nodeRef} />
       </Transition>
     )
 
-    inst.setProps({ in: true })
+    wrapper.setProps({ in: true })
   })
 
   it('should fallback to timeouts with addEndListener', done => {
     let calledEnd = false
-    let listener = (node, end) =>
+    let listener = (end) =>
       setTimeout(() => {
         calledEnd = true
         end()
       }, 100)
 
-    let inst = mount(
+    const nodeRef = React.createRef()
+    let wrapper = mount(
       <Transition
         timeout={0}
+        nodeRef={nodeRef}
         addEndListener={listener}
         onEntered={() => {
           expect(calledEnd).toEqual(false)
           done()
         }}
       >
-        <div />
+        <div ref={nodeRef} />
       </Transition>
     )
 
-    inst.setProps({ in: true })
+    wrapper.setProps({ in: true })
   })
 
   it('should mount/unmount immediately if not have enter/exit timeout', (done) => {
+    const nodeRef = React.createRef()
     const wrapper = mount(
-      <Transition in={true} timeout={{}}>
-        <div />
+      <Transition nodeRef={nodeRef} in={true} timeout={{}}>
+        <div ref={nodeRef} />
       </Transition>
     )
 
@@ -164,9 +175,10 @@ describe('Transition', () => {
       setTimeout(() => {
         calledBeforeEntered = true
       }, 10)
+      const nodeRef = React.createRef()
       const wrapper = mount(
-        <Transition in={true} timeout={{ enter: 20, exit: 10 }} appear>
-          <div />
+        <Transition nodeRef={nodeRef} in={true} timeout={{ enter: 20, exit: 10 }} appear>
+          <div ref={nodeRef} />
         </Transition>
       )
 
@@ -182,9 +194,10 @@ describe('Transition', () => {
     })
 
     it('should use appear timeout if appear is set', done => {
+      const nodeRef = React.createRef()
       const wrapper = mount(
-        <Transition in={true} timeout={{ enter: 20, exit: 10, appear: 5 }} appear>
-          <div />
+        <Transition nodeRef={nodeRef} in={true} timeout={{ enter: 20, exit: 10, appear: 5 }} appear>
+          <div ref={nodeRef} />
         </Transition>
       )
 
@@ -206,12 +219,13 @@ describe('Transition', () => {
   })
 
   describe('entering', () => {
-    let wrapper
+    let wrapper, nodeRef;
 
     beforeEach(() => {
+      nodeRef = React.createRef()
       wrapper = mount(
-        <Transition timeout={10}>
-          <div />
+        <Transition nodeRef={nodeRef} timeout={10}>
+          <div ref={nodeRef} />
         </Transition>
       )
     })
@@ -267,12 +281,13 @@ describe('Transition', () => {
   })
 
   describe('exiting', () => {
-    let wrapper
+    let wrapper, nodeRef;
 
     beforeEach(() => {
+      nodeRef = React.createRef()
       wrapper = mount(
-        <Transition in timeout={10}>
-          <div />
+        <Transition nodeRef={nodeRef} in timeout={10}>
+          <div ref={nodeRef} />
         </Transition>
       )
     })
@@ -329,10 +344,8 @@ describe('Transition', () => {
 
   describe('mountOnEnter', () => {
     class MountTransition extends React.Component {
-      constructor(props) {
-        super(props)
-        this.state = { in: props.initialIn }
-      }
+      nodeRef = React.createRef()
+      state = { in: this.props.initialIn }
 
       render() {
         const { ...props } = this.props
@@ -341,12 +354,13 @@ describe('Transition', () => {
         return (
           <Transition
             ref={transition => this.transition = this.transition || transition}
+            nodeRef={this.nodeRef}
             mountOnEnter
             in={this.state.in}
             timeout={10}
             {...props}
           >
-            <div />
+            <div ref={this.nodeRef} />
           </Transition>
         )
       }
@@ -362,7 +376,7 @@ describe('Transition', () => {
           initialIn={false}
           onEnter={() => {
             expect(wrapper.instance().getStatus()).toEqual(EXITED)
-            expect(wrapper.getDOMNode()).toExist()
+            expect(wrapper.instance().nodeRef.current).toExist()
             done()
           }}
         />
@@ -370,7 +384,7 @@ describe('Transition', () => {
 
       expect(wrapper.instance().getStatus()).toEqual(UNMOUNTED)
 
-      expect(wrapper.getDOMNode()).not.toExist()
+      expect(wrapper.instance().nodeRef.current).not.toExist()
 
       wrapper.setProps({ in: true })
     })
@@ -381,27 +395,27 @@ describe('Transition', () => {
           initialIn={false}
           onEntered={() => {
             expect(wrapper.instance().getStatus()).toEqual(ENTERED)
-            expect(wrapper.getDOMNode()).toExist()
+            expect(wrapper.instance().nodeRef.current).toExist()
 
             wrapper.setState({ in: false })
           }}
           onExited={() => {
             expect(wrapper.instance().getStatus()).toEqual(EXITED)
-            expect(wrapper.getDOMNode()).toExist()
+            expect(wrapper.instance().nodeRef.current).toExist()
 
             done()
           }}
         />
       )
 
-      expect(wrapper.getDOMNode()).not.toExist()
+      expect(wrapper.instance().nodeRef.current).not.toExist()
       wrapper.setState({ in: true })
     })
   })
 
   describe('unmountOnExit', () => {
     class UnmountTransition extends React.Component {
-      divRef = React.createRef()
+      nodeRef = React.createRef()
       state = { in: this.props.initialIn }
 
       render() {
@@ -411,12 +425,13 @@ describe('Transition', () => {
         return (
           <Transition
             ref={transition => this.transition = this.transition || transition}
+            nodeRef={this.nodeRef}
             unmountOnExit
             in={this.state.in}
             timeout={10}
             {...props}
           >
-            <div ref={this.divRef} />
+            <div ref={this.nodeRef} />
           </Transition>
         )
       }
@@ -427,42 +442,42 @@ describe('Transition', () => {
     }
 
     it('should mount when entering', done => {
-      const wrapper = mount(
+      const instance = mount(
         <UnmountTransition
           initialIn={false}
           onEnter={() => {
-            expect(wrapper.getStatus()).toEqual(EXITED)
-            expect(wrapper.divRef.current).toExist()
+            expect(instance.getStatus()).toEqual(EXITED)
+            expect(instance.nodeRef.current).toExist()
 
             done()
           }}
         />
       ).instance()
 
-      expect(wrapper.getStatus()).toEqual(UNMOUNTED)
-      expect(wrapper.divRef.current).toBeNull()
+      expect(instance.getStatus()).toEqual(UNMOUNTED)
+      expect(instance.nodeRef.current).toBeNull()
 
-      wrapper.setState({ in: true })
+      instance.setState({ in: true })
     })
 
     it('should unmount after exiting', done => {
-      const wrapper = mount(
+      const instance = mount(
         <UnmountTransition
           initialIn
           onExited={() => {
             setTimeout(() => {
-              expect(wrapper.getStatus()).toEqual(UNMOUNTED)
-              expect(wrapper.divRef.current).not.toExist()
+              expect(instance.getStatus()).toEqual(UNMOUNTED)
+              expect(instance.nodeRef.current).not.toExist()
               done()
             })
           }}
         />
       ).instance()
 
-      expect(wrapper.getStatus()).toEqual(ENTERED)
-      expect(wrapper.divRef.current).toExist()
+      expect(instance.getStatus()).toEqual(ENTERED)
+      expect(instance.nodeRef.current).toExist()
 
-      wrapper.setState({ in: false })
+      instance.setState({ in: false })
     })
   })
 })

--- a/test/Transition-test.js
+++ b/test/Transition-test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
 
 import { mount } from 'enzyme'
 
@@ -167,6 +168,35 @@ describe('Transition', () => {
         throw new Error('wrong timeout')
       }
     })
+  })
+
+  it('should use `React.findDOMNode` when `nodeRef` is not provided', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    const findDOMNodeSpy = jest.spyOn(ReactDOM, 'findDOMNode')
+
+    mount(
+      <Transition in appear timeout={0}>
+        <div />
+      </Transition>
+    )
+
+    expect(findDOMNodeSpy).toHaveBeenCalled();
+    findDOMNodeSpy.mockRestore()
+    consoleSpy.mockRestore()
+  })
+
+  it('should not use `React.findDOMNode` when `nodeRef` is provided', () => {
+    const findDOMNodeSpy = jest.spyOn(ReactDOM, 'findDOMNode')
+
+    const nodeRef = React.createRef()
+    mount(
+      <Transition nodeRef={nodeRef} in appear timeout={0}>
+        <div ref={nodeRef} />
+      </Transition>
+    )
+
+    expect(findDOMNodeSpy).not.toHaveBeenCalled();
+    findDOMNodeSpy.mockRestore()
   })
 
   describe('appearing timeout', () => {

--- a/test/TransitionGroup-test.js
+++ b/test/TransitionGroup-test.js
@@ -20,18 +20,19 @@ describe('TransitionGroup', () => {
 
     log = []
     let events = {
-      onEnter: (_, m) => log.push(m ? 'appear' : 'enter'),
-      onEntering: (_, m) => log.push(m ? 'appearing' : 'entering'),
-      onEntered: (_, m) => log.push(m ? 'appeared' : 'entered'),
+      onEnter: (m) => log.push(m ? 'appear' : 'enter'),
+      onEntering: (m) => log.push(m ? 'appearing' : 'entering'),
+      onEntered: (m) => log.push(m ? 'appeared' : 'entered'),
       onExit: () => log.push('exit'),
       onExiting: () => log.push('exiting'),
       onExited: () => log.push('exited'),
     }
 
+    const nodeRef = React.createRef()
     Child = function Child(props) {
       return (
-        <Transition timeout={0} {...props} {...events}>
-          <span />
+        <Transition nodeRef={nodeRef} timeout={0} {...props} {...events}>
+          <span ref={nodeRef} />
         </Transition>
       )
     }

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,4 @@
+import { StrictMode, createElement } from 'react'
 
 global.requestAnimationFrame = function(callback) {
   setTimeout(callback, 0);
@@ -6,4 +7,7 @@ global.requestAnimationFrame = function(callback) {
 const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 
-Enzyme.configure({ adapter: new Adapter() })
+Enzyme.configure({
+  adapter: new Adapter(),
+  wrappingComponent: props => createElement(StrictMode, props)
+})

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,4 @@
-import { StrictMode, createElement } from 'react'
+import React from 'react'
 
 global.requestAnimationFrame = function(callback) {
   setTimeout(callback, 0);
@@ -9,5 +9,5 @@ const Adapter = require('enzyme-adapter-react-16');
 
 Enzyme.configure({
   adapter: new Adapter(),
-  wrappingComponent: props => createElement(StrictMode, props)
+  wrappingComponent: props => <React.StrictMode {...props} />
 })


### PR DESCRIPTION
* [x] Add `nodeRef` alternative for internal `findDOMNode`
* [x] Adapted tests
* [x] Added Tests
* [x] Adapted stories


We can name prop one of this:
- `domRef`
- `nodeRef` ✓
- `guestRef`
- `transitionRef`
- `ref` (with `forwardRef` but BREAKING CHANGE)

#### PRs:

Closes #457
Closes #486
Closes #514

#### Issues:

Closes #287
Closes #429