### PR TITLE
prefix UNSAFE_ to componentWillReceiveProps lifecycle method in tests

### DIFF
--- a/test/TransitionGroup-test.js
+++ b/test/TransitionGroup-test.js
@@ -102,7 +102,7 @@ describe('TransitionGroup', () => {
 
   it('should not throw when enter callback is called and is now leaving', () => {
     class Child extends React.Component {
-      componentWillReceiveProps() {
+      UNSAFE_componentWillReceiveProps() {
         if (this.callback) {
           this.callback()
         }
@@ -139,7 +139,7 @@ describe('TransitionGroup', () => {
 
   it('should not throw when leave callback is called and is now entering', () => {
     class Child extends React.Component {
-      componentWillReceiveProps() {
+      UNSAFE_componentWillReceiveProps() {
         if (this.callback) {
           this.callback()
         }


### PR DESCRIPTION
Unsafe lifecycles  (componentWillReceiveProps) will continue to work until upcoming React version 17. 
[docs](https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops)

Gradual migration for these lifecycle methods includes prefixing `UNSAFE_` which will prevent deprecation errors and indicate that using these `UNSAFE_` lifecycles will be more prone to bugs in the future.