### PR TITLE
Prefix more lifecycles with UNSAFE_ (fix Warnings)

### DIFF
--- a/index.js
+++ b/index.js
@@ -454,7 +454,7 @@ var TransitionGroup = function (_React$Component) {
     return _this;
   }
 
-  TransitionGroup.prototype.componentWillMount = function componentWillMount() {
+  TransitionGroup.prototype.UNSAFE_componentWillMount = function UNSAFE_componentWillMount() {
     this.currentlyTransitioningKeys = {};
     this.keysToEnter = [];
     this.keysToLeave = [];
@@ -469,7 +469,7 @@ var TransitionGroup = function (_React$Component) {
     }
   };
 
-  TransitionGroup.prototype.componentWillReceiveProps = function componentWillReceiveProps(nextProps) {
+  TransitionGroup.prototype.UNSAFE_componentWillReceiveProps = function UNSAFE_componentWillReceiveProps(nextProps) {
     var nextChildMapping = (0, _ChildMapping.getChildMapping)(nextProps.children);
     var prevChildMapping = this.state.children;
 
@@ -1922,7 +1922,7 @@ var CSSTransitionGroupChild = function (_React$Component) {
     }, _temp), _possibleConstructorReturn(_this, _ret);
   }
 
-  CSSTransitionGroupChild.prototype.componentWillMount = function componentWillMount() {
+  CSSTransitionGroupChild.prototype.UNSAFE_componentWillMount = function UNSAFE_componentWillMount() {
     this.classNameAndNodeQueue = [];
     this.transitionTimeouts = [];
   };

--- a/test/TransitionGroup-test.js
+++ b/test/TransitionGroup-test.js
@@ -443,7 +443,7 @@ describe('TransitionGroup', () => {
 
   it('should not throw when enter callback is called and is now leaving', () => {
     class Child extends React.Component {
-      componentWillReceiveProps() {
+      UNSAFE_componentWillReceiveProps() {
         if (this.callback) {
           this.callback();
         }
@@ -482,7 +482,7 @@ describe('TransitionGroup', () => {
 
   it('should not throw when leave callback is called and is now entering', () => {
     class Child extends React.Component {
-      componentWillReceiveProps() {
+      UNSAFE_componentWillReceiveProps() {
         if (this.callback) {
           this.callback();
         }


### PR DESCRIPTION
This is a naive patch. It's working with react 16.11.0. I had thought I was using react 16.10. Whadayaknow. 