### PR TITLE
Remove enter and exit classes if config.disabled is true

### DIFF
--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -4,6 +4,8 @@ import addOneClass from 'dom-helpers/addClass';
 import removeOneClass from 'dom-helpers/removeClass';
 import React from 'react';
 
+import config from './config';
+
 import Transition from './Transition';
 import { classNamesShape } from './utils/PropTypes';
 
@@ -108,6 +110,10 @@ class CSSTransition extends React.Component {
     this.removeClasses(node, type);
     this.addClass(node, type, 'done');
 
+    if(this.config.disabled) {
+      this.removeClasses(node, 'exit');
+    }
+
     if (this.props.onEntered) {
       this.props.onEntered(node, appearing)
     }
@@ -134,6 +140,10 @@ class CSSTransition extends React.Component {
   onExited = (node) => {
     this.removeClasses(node, 'exit');
     this.addClass(node, 'exit', 'done');
+
+    if(this.config.disabled) {
+      this.removeClasses(node, 'enter');
+    }
 
     if (this.props.onExited) {
       this.props.onExited(node)

--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -110,7 +110,7 @@ class CSSTransition extends React.Component {
     this.removeClasses(node, type);
     this.addClass(node, type, 'done');
 
-    if(this.config.disabled) {
+    if (config.disabled) {
       this.removeClasses(node, 'exit');
     }
 
@@ -141,7 +141,7 @@ class CSSTransition extends React.Component {
     this.removeClasses(node, 'exit');
     this.addClass(node, 'exit', 'done');
 
-    if(this.config.disabled) {
+    if (config.disabled) {
       this.removeClasses(node, 'enter');
     }
 


### PR DESCRIPTION
This pull request relates to https://github.com/reactjs/react-transition-group/issues/341 and ensures that only the `*-enter-done` and `*-exit-done` should exist on the tested DOM node when `config.disabled` is set to`true`

Credit goes to @joefurniss for spotting this issue.

#### Testing Components with Transitions
https://reactcommunity.org/react-transition-group/testing/

