### PR TITLE
docs(SwitchTransition): Add info when TransitionGroup should be used instead

### DIFF
--- a/src/SwitchTransition.js
+++ b/src/SwitchTransition.js
@@ -78,6 +78,12 @@ const enterRenders = {
  * If the `out-in` mode is selected, the `SwitchTransition` waits until the old child leaves and then inserts a new child.
  * If the `in-out` mode is selected, the `SwitchTransition` inserts a new child first, waits for the new child to enter and then removes the old child
  *
+ * **Note**: If you want the animation to happen simultaneously 
+ * (that is, to have the old child removed and a new child inserted **at the same time**),
+ * you should use 
+ * [`TransitionGroup`](https://reactcommunity.org/react-transition-group/transition-group)
+ * instead.
+ *
  * ```jsx
  *
  * function App() {


### PR DESCRIPTION
See https://github.com/reactjs/react-transition-group/issues/601 for why this note might be useful.