### PR TITLE
docs: replace fraudulent nganimate.com link by a link to the official angular documentation

### DIFF
--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -12,7 +12,7 @@ const removeClass = (node, classes) => node && classes && classes.split(' ').for
 
 /**
  * A transition component inspired by the excellent
- * [ng-animate](http://www.nganimate.org/) library, you should use it if you're
+ * [ng-animate](https://docs.angularjs.org/api/ngAnimate) library, you should use it if you're
  * using CSS transitions or animations. It's built upon the
  * [`Transition`](https://reactcommunity.org/react-transition-group/transition)
  * component, so it inherits all of its props.


### PR DESCRIPTION
Fixes #603 