### PR TITLE
Update comment in addClass function

### DIFF
--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -190,7 +190,7 @@ class CSSTransition extends React.Component {
       className += ` ${doneClassName}`;
     }
 
-    // This is for to force a repaint,
+    // This is to force a repaint,
     // which is necessary in order to transition styles when adding a class name.
     if (phase === 'active') {
       /* eslint-disable no-unused-expressions */


### PR DESCRIPTION
Issue for reference: https://github.com/reactjs/react-transition-group/issues/634

- Removes the `for` in the addClass comments; updated comment becomes `This is to repaint...`