### PR TITLE
fix(Transition): Don't warn on cross-realm nodes

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -391,9 +391,19 @@ Transition.propTypes = {
    *     [test/CSSTransition-test.js](https://github.com/reactjs/react-transition-group/blob/13435f897b3ab71f6e19d724f145596f5910581c/test/CSSTransition-test.js#L362-L437)).
    */
   nodeRef: PropTypes.shape({
-    current: typeof Element === 'undefined'
-      ? PropTypes.any
-      : PropTypes.instanceOf(Element)
+    current: (propValue, key, componentName) => {
+      const instance = propValue[key];
+      if (instance === undefined || instance === null) {
+        return null
+      }
+      // Element.prototype.nodeType === 1
+      // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#Node_type_constants
+      if (instance.nodeType === 1) {
+        return null;
+      }
+      const actualClassName = !instance.constructor || !instance.constructor.name ? '<<anonymous>>' : instance.constructor.name;
+      return new Error('Invalid props `nodeRef.current` of type `' + actualClassName + '` supplied to `' + componentName + '`, expected instance of `Element`.')
+    }
   }),
 
   /**

--- a/test/Transition-test.js
+++ b/test/Transition-test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import * as PropTypes from 'prop-types'
 
 import { mount } from 'enzyme'
 
@@ -508,6 +509,33 @@ describe('Transition', () => {
       expect(instance.nodeRef.current).toExist()
 
       instance.setState({ in: false })
+    })
+  })
+
+  describe('propTypes', () => {
+    beforeEach(() => {
+      PropTypes.resetWarningCache()
+      jest.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      console.error.mockRestore()
+    })
+
+    it('does not error if nodeRef.current is null', () => {
+      PropTypes.checkPropTypes(Transition.propTypes, { nodeRef: { current: undefined }, children: <div />, timeout: 0  }, 'props', 'Transition')
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+
+      PropTypes.checkPropTypes(Transition.propTypes, { nodeRef: { current: null }, children: <div />, timeout: 0 }, 'props', 'Transition')
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+    })
+
+    it('errors if nodeRef.current is not an Element', () => {
+      PropTypes.checkPropTypes(Transition.propTypes, { nodeRef: { current: document }, children: <div />, timeout: 0 }, 'props', 'Transition')
+
+      expect(console.error).toHaveBeenCalledWith('Warning: Failed props type: Invalid props `nodeRef.current` of type `Document` supplied to `Transition`, expected instance of `Element`.')
     })
   })
 })

--- a/test/Transition-test.js
+++ b/test/Transition-test.js
@@ -522,12 +522,16 @@ describe('Transition', () => {
       console.error.mockRestore()
     })
 
-    it('does not error if nodeRef.current is null', () => {
+    it('does not error if nodeRef.current is nullish | Element', () => {
       PropTypes.checkPropTypes(Transition.propTypes, { nodeRef: { current: undefined }, children: <div />, timeout: 0  }, 'props', 'Transition')
 
       expect(console.error).toHaveBeenCalledTimes(0);
 
       PropTypes.checkPropTypes(Transition.propTypes, { nodeRef: { current: null }, children: <div />, timeout: 0 }, 'props', 'Transition')
+
+      expect(console.error).toHaveBeenCalledTimes(0);
+
+      PropTypes.checkPropTypes(Transition.propTypes, { nodeRef: { current: document.createElement('div') }, children: <div />, timeout: 0 }, 'props', 'Transition')
 
       expect(console.error).toHaveBeenCalledTimes(0);
     })


### PR DESCRIPTION
`node instanceOf Element` checks return false if the node comes from a different window than where the `Transition` module was initialized.

As far as I can tell we don't care if the node is from a different window. We're only interested in the implemented interface so checking for [`nodeType`](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#Node_type_constants) should be sufficient.

The test passes for the previous and proposed implementation without changing the error message. We could just go with `PropTypes.shape({ nodeType: PropTypes.oneOf([1]).isRequired })` but the error message would not be helpful since it wouldn't mention `Element` at all.

Resolves https://github.com/reactjs/react-transition-group/issues/618#issuecomment-624344177
Resolves https://github.com/reactjs/react-transition-group/pull/619#discussion_r457550929