### PR TITLE
Fixed `nodeRef` prop type for cross-frame elements

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -391,9 +391,18 @@ Transition.propTypes = {
    *     [test/CSSTransition-test.js](https://github.com/reactjs/react-transition-group/blob/13435f897b3ab71f6e19d724f145596f5910581c/test/CSSTransition-test.js#L362-L437)).
    */
   nodeRef: PropTypes.shape({
-    current: typeof Element === 'undefined'
-      ? PropTypes.any
-      : PropTypes.instanceOf(Element)
+    current:
+      typeof Element === 'undefined'
+        ? PropTypes.any
+        : (propValue, key, componentName, location, propFullName, secret) => {
+            const value = propValue[key];
+
+            return PropTypes.instanceOf(
+              value && 'ownerDocument' in value
+                ? value.ownerDocument.defaultView.Element
+                : Element
+            )(propValue, key, componentName, location, propFullName, secret);
+          },
   }),
 
   /**


### PR DESCRIPTION
Demo of the problem (and the fix if you uncomment it) presented here: https://codesandbox.io/s/naughty-dan-zps3f?file=/src/App.js

Simple `instanceof` checks always fail for cross-realm checks as technically each realm gets its own, pristine, environment which includes all global constructors (such as `Element`)