### PR TITLE
Update Transition.js

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -126,7 +126,7 @@ class Transition extends React.Component {
         initialStatus = ENTERED;
       }
     } else {
-      if (props.unmountOnExit || props.mountOnEnter) {
+      if (props.unmountOnExit || !props.mountOnEnter) {
         initialStatus = UNMOUNTED;
       } else {
         initialStatus = EXITED;


### PR DESCRIPTION
The initial status should be `unmount` when  setting `mountOnEnter` as `false`, for lazy load just at first render.