### PR TITLE
add process guard

### DIFF
--- a/src/utils/PropTypes.js
+++ b/src/utils/PropTypes.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
 export const timeoutsShape =
-  process.env.NODE_ENV !== 'production'
+  typeof process !== 'undefined' && process.env.NODE_ENV !== 'production'
     ? PropTypes.oneOfType([
         PropTypes.number,
         PropTypes.shape({
@@ -13,7 +13,7 @@ export const timeoutsShape =
     : null;
 
 export const classNamesShape =
-  process.env.NODE_ENV !== 'production'
+  typeof process !== 'undefined' && process.env.NODE_ENV !== 'production'
     ? PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.shape({


### PR DESCRIPTION
This fixes react-transition-group to work with `"module"` resolution on JSPM. See the example at https://jspm.org/sandbox#H4sIAAAAAAAAA61W32/aMBB+719xy172o0lKta6MQUXHqqobdFVp1e3RJAfxFtuRz0DptP99FwcYoJZW2x4gsn333Xd38XdpPktN4mYFQuZUfrTTXDxQpEc7AE2FTkCSCUvoWsHYDcN64A+cdDkeXWv/TJtxtV66aKGwFUwkTgtjXQCJ0Q41Q0xl6rJWihOZYOgXuyC1dFLkISUix1aNAzTjikFzYNKZR30WhvwA+NS/6MEparTCGQtnqsSHnij86UkqHVxfdhucjyuoEcejhWn0nQoVSRM/v94/z76dfvjxsbdnZ/27T/3rWvb5pDi/6hxedvv557vO5Eu3p3t3787Pu3Uz6X49nu5dXVz2pmfHQ9W5cX065mhh6IlRYmXhoCxiK5CejhKFL9JPz2m+SUFjvsFbFkXiQmeFJk7d6HBkzbhgi2DJWywJ60I17ndov4neRPsxkoqlTvGWXQIf4tduFZoSU+Ba5HvwV47ZoD0QA8xjO+bWKuQ+5AVa8jEEEVp3lUk6qzom7zDdQnodqn0Y1d5GB48jllnsPokQ3vJLldI/UZhjPD2o1Bla6ahrDOE/hV5DejoBM/iOibuRLjNjd2G5w9ZJ/A98tgFv0EuNCheuIk07OXdyS+wV8/ZBtB/tVd2fO27BtqjMBP8OfsV3I0KVaMgHcqS34K7Z8WWrRbU/F20Fr+BahaUCbCP5x6hdO4jqTPI+KH/RHxOCdu0w2uOL/yBAyBV5VE3YZhsQJRmm4xztFqClTZtR1oDmOL92Fv/lrxlXalmK41zU4aQPPVNiQD+TihoLSWcRJShMPhvKPIcha73yZgQDa6YsGwTT6k0FueJB48IvXgj2wtsEWZs7mTUKof7u9csN1RY00wmQTVoPZYgUVnFDKulxnrX9qB6nkly8cRYpqcvUIbGGyFg5kroVCG30TJkxBUeb6a+NjgrJzw1YZPSKCYJv1tVS+U9L4YchZ/TgGHlf4QPEMdywwCCXRup5/XgUpzzu0eIucFE5gADCQvCQROBaoy8rbwZclgCEc1YOxnxmNLgMFygV98iH4eFOJscoN6MX97F9+X6t9824muo85P3Xxm9INbHXhQgAAA== for the issue.