### PR TITLE
ci: run CI on the alpha branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, alpha]
   pull_request:
-    branches: [master]
+    branches: [master, alpha]
 
 jobs:
   test:


### PR DESCRIPTION
We should run CI on the alpha branch
