### PR TITLE
build(peer-deps): add React v17 & v18 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     ]
   },
   "peerDependencies": {
-    "react": ">=16.6.0",
-    "react-dom": ">=16.6.0"
+    "react": ">=16.6.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": ">=16.6.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",


### PR DESCRIPTION
Should fix issues like #834.

The default dev version of React is now v18. So I open it as a draft since I'm not sure yet if we need more tests to ensure this change is valid.

Maybe #815 would force us to break from v16 support?