### PR TITLE
docs: clarify that nodeRef changes fn signature

### DIFF
--- a/src/CSSTransition.js
+++ b/src/CSSTransition.js
@@ -318,7 +318,7 @@ CSSTransition.propTypes = {
    * A `<Transition>` callback fired immediately after the 'enter' or 'appear' class is
    * applied.
    *
-   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed, so `isAppearing` is being passed as the first argument.
    *
    * @type Function(node: HtmlElement, isAppearing: bool)
    */
@@ -328,7 +328,7 @@ CSSTransition.propTypes = {
    * A `<Transition>` callback fired immediately after the 'enter-active' or
    * 'appear-active' class is applied.
    *
-   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed, so `isAppearing` is being passed as the first argument.
    *
    * @type Function(node: HtmlElement, isAppearing: bool)
    */
@@ -338,7 +338,7 @@ CSSTransition.propTypes = {
    * A `<Transition>` callback fired immediately after the 'enter' or
    * 'appear' classes are **removed** and the `done` class is added to the DOM node.
    *
-   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed, so `isAppearing` is being passed as the first argument.
    *
    * @type Function(node: HtmlElement, isAppearing: bool)
    */

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -513,7 +513,7 @@ Transition.propTypes = {
    * DOM node and a `done` callback. Allows for more fine grained transition end
    * logic. Timeouts are still used as a fallback if provided.
    *
-   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed, so `done` is being passed as the first argument.
    *
    * ```jsx
    * addEndListener={(node, done) => {
@@ -528,7 +528,7 @@ Transition.propTypes = {
    * Callback fired before the "entering" status is applied. An extra parameter
    * `isAppearing` is supplied to indicate if the enter stage is occurring on the initial mount
    *
-   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed, so `isAppearing` is being passed as the first argument.
    *
    * @type Function(node: HtmlElement, isAppearing: bool) -> void
    */
@@ -538,7 +538,7 @@ Transition.propTypes = {
    * Callback fired after the "entering" status is applied. An extra parameter
    * `isAppearing` is supplied to indicate if the enter stage is occurring on the initial mount
    *
-   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed, so `isAppearing` is being passed as the first argument.
    *
    * @type Function(node: HtmlElement, isAppearing: bool)
    */
@@ -548,7 +548,7 @@ Transition.propTypes = {
    * Callback fired after the "entered" status is applied. An extra parameter
    * `isAppearing` is supplied to indicate if the enter stage is occurring on the initial mount
    *
-   * **Note**: when `nodeRef` prop is passed, `node` is not passed.
+   * **Note**: when `nodeRef` prop is passed, `node` is not passed, so `isAppearing` is being passed as the first argument.
    *
    * @type Function(node: HtmlElement, isAppearing: bool) -> void
    */


### PR DESCRIPTION
Passing `nodeRef` changes the function signature of certain props, these additions aim to make this more obvious.

Resolves #623.