### PR TITLE
Remove "@1.x" from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The recommended installation method is through either [npm](https://www.npmjs.co
 
 ```sh
 # npm
-npm install react-transition-group@1.x --save
+npm install react-transition-group --save
 
 # yarn
-yarn add react-transition-group@1.x
+yarn add react-transition-group
 ```
 
 ## CDN / External


### PR DESCRIPTION
Looks like 1.x versions require an older version of React, I assume this could be dropped.