### PR TITLE
fix: perform sync update when exiting animation

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -291,8 +291,10 @@ class Transition extends React.Component {
       this.props.onExiting(maybeNode);
 
       this.onTransitionEnd(timeouts.exit, () => {
-        this.safeSetState({ status: EXITED }, () => {
-          this.props.onExited(maybeNode);
+        ReactDOM.flushSync(() => {
+          this.safeSetState({ status: EXITED }, () => {
+            this.props.onExited(maybeNode);
+          });
         });
       });
     });


### PR DESCRIPTION
When running in React 18 concurrent mode some state updates are batched, which results in inconsistent timing of events compared to the legacy mode. For example when using animations, after `animationend` event fires, the `onExited` event is not fired immediately, so there is a brief period of time when animation is finished and the styles are reset back to normal, which may cause a flash or a jump. One of these scenarios is described in #816.

This change makes sure that the updates are performed synchronously, in order to make sure that events fire consistently.